### PR TITLE
Finalize section pages and room layout

### DIFF
--- a/frontend/src/pages/SectionPage.css
+++ b/frontend/src/pages/SectionPage.css
@@ -1,110 +1,473 @@
 /* frontend/src/pages/SectionPage.css */
+:root {
+  --sections-sidebar-width: 260px;
+  --sections-rail-width: 320px;
+}
+
 .sections-page {
-  display: grid; grid-template-columns: 260px 1fr;
+  display: grid;
+  grid-template-columns: var(--sections-sidebar-width) minmax(0, 1fr) var(--sections-rail-width);
+  gap: 1.25rem;
   min-height: calc(100vh - 64px);
   background: var(--color-background, #0f0f12);
   color: var(--color-text, #eaeaea);
+  padding: 1.5rem clamp(1rem, 3vw, 2rem);
+  box-sizing: border-box;
+}
+
+.sections-sidebar,
+.sections-rail {
+  background: var(--color-surface, #141418);
+  border: 1px solid var(--color-border, #2a2a32);
+  border-radius: 18px;
+  padding: 1rem;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.25);
+  position: sticky;
+  top: 80px;
+  align-self: start;
+  max-height: calc(100vh - 96px);
+  overflow: auto;
+}
+
+.sections-main {
+  display: grid;
+  gap: 1.5rem;
+  align-content: start;
 }
 
 /* Sidebar */
-.sections-sidebar {
-  border-right: 1px solid var(--color-border, #2a2a32);
-  padding: 1rem; position: sticky; top: 64px; align-self: start;
-  height: calc(100vh - 64px); overflow: auto; background: var(--color-surface, #141418);
+.sidebar-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
 }
-.sidebar-head { display:flex; align-items:center; justify-content:space-between; }
-.sidebar-head h2 { margin:0 0 .75rem 0; font-family: var(--font-glow, ui-sans-serif); font-size:1.1rem; color: #a8e4ff; }
-.section-list { margin:0; padding:0; list-style:none; display:grid; gap:.25rem; }
-.section-item { border-radius: 10px; }
-.section-link {
-  display:grid; grid-template-columns: 12px 24px 1fr; gap:.5rem; align-items:center;
-  padding:.5rem .6rem; border-radius:10px; text-decoration:none; color:inherit;
+
+.sidebar-head h2 {
+  margin: 0;
+  font-family: var(--font-glow, ui-sans-serif);
+  font-size: 1.2rem;
+  color: var(--color-accent-dark, #c9b6ff);
 }
-.section-link:hover { background: rgba(255,255,255,0.04); }
-.section-item.active .section-link { background: rgba(92,194,255,0.16); outline:1px solid rgba(92,194,255,0.35); }
-.color-dot { width:12px; height:12px; border-radius:50%; border:1px solid rgba(0,0,0,.2); }
-.icon { font-size:1rem; filter: saturate(1.2); }
-.label { font-family: var(--font-thread, ui-sans-serif); }
 
-/* Main */
-.sections-main { padding: 1rem 1.25rem 3rem; }
-.sections-header {
-  display:flex; align-items:center; justify-content:space-between;
-  border-bottom: 1px solid var(--color-border, #2a2a32);
-  padding-bottom:.75rem; margin-bottom:1rem;
+.sidebar-count {
+  font-size: 0.85rem;
+  color: var(--color-muted, #9aa0aa);
 }
-.sections-header .title h1 { margin:0; font-family: var(--font-glow, ui-sans-serif); font-size:1.5rem; }
-.sections-header .subtitle { color: var(--color-muted,#9aa0aa); font-size:.9rem; margin-top:.25rem; }
 
-.controls { display:flex; gap:.5rem; align-items:center; }
-.btn {
-  background: var(--color-thread, #6b6bff); color: var(--color-mist, #fff);
-  border:none; border-radius:10px; padding:.5rem .7rem; cursor:pointer;
-  box-shadow: 0 2px 8px rgba(0,0,0,.2);
+.section-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.35rem;
 }
-.btn:hover { filter: brightness(1.05); }
-.btn.ghost { background: transparent; color: #a8e4ff; border:1px solid var(--color-border,#2a2a32); }
-.btn.sm { padding:.25rem .5rem; font-size:.85rem; }
 
-.toast { margin:.75rem 0 0; background: rgba(100,255,200,.08); border:1px solid rgba(100,255,200,.25); padding:.5rem .75rem; border-radius:8px; font-size:.9rem; }
-.loading { display:grid; place-items:center; padding:2rem 0; }
-.spin { width:26px; height:26px; border-radius:50%; border:3px solid rgba(255,255,255,.15); border-top-color:#a8e4ff; animation: spin .9s linear infinite; }
-@keyframes spin { to { transform: rotate(360deg); } }
+.section-item .section-link {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 16px 28px 1fr;
+  gap: 0.65rem;
+  align-items: center;
+  padding: 0.55rem 0.65rem;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+  font-size: 0.95rem;
+  transition: background 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
+}
 
-.grid { display:grid; gap:1rem; grid-template-columns: repeat(2, minmax(0,1fr)); }
-.section { background: var(--color-surface, #141418); border:1px solid var(--color-border,#2a2a32); border-radius:14px; padding:.75rem; box-shadow:0 8px 20px rgba(0,0,0,.2); }
-.section-head { display:flex; align-items:center; justify-content:space-between; border-bottom:1px solid var(--color-border,#2a2a32); padding-bottom:.5rem; margin-bottom:.5rem; }
-.section-head h3 { margin:0; font-family: var(--font-glow, ui-sans-serif); font-size:1.05rem; color:#cfefff; }
-.hint { color: var(--color-muted,#9aa0aa); font-size:.85rem; }
+.section-item .section-link:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
 
-.quick-add { display:flex; gap:.4rem; align-items:center; }
-.quick-add input {
-  background: rgba(255,255,255,0.03);
+.section-item.active .section-link {
+  background: rgba(155, 135, 245, 0.18);
+  border-color: rgba(155, 135, 245, 0.4);
+  box-shadow: inset 0 0 0 1px rgba(155, 135, 245, 0.22);
+}
+
+.section-item .color-dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 1px solid rgba(0, 0, 0, 0.35);
+}
+
+.section-item .icon {
+  font-size: 1.1rem;
+}
+
+.section-item .label {
+  font-family: var(--font-thread, ui-sans-serif);
+  letter-spacing: 0.01em;
+}
+
+/* Landing */
+.sections-landing {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.sections-hero {
+  background: linear-gradient(135deg, rgba(155, 135, 245, 0.16), rgba(112, 210, 255, 0.12));
+  border: 1px solid rgba(155, 135, 245, 0.35);
+  border-radius: 20px;
+  padding: 2rem clamp(1.2rem, 3vw, 2.6rem);
+  box-shadow: 0 18px 38px rgba(0, 0, 0, 0.28);
+}
+
+.sections-hero h1 {
+  margin: 0 0 0.75rem 0;
+  font-family: var(--font-glow, ui-sans-serif);
+  font-size: clamp(1.5rem, 3vw, 2rem);
+}
+
+.sections-hero p {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--color-muted, #9aa0aa);
+  max-width: 42ch;
+}
+
+.sections-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.section-card {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+  width: 100%;
+  background: var(--color-surface, #141418);
   border: 1px solid var(--color-border, #2a2a32);
-  border-radius: 10px; padding: .35rem .55rem; color: inherit; min-width: 220px;
+  border-radius: 16px;
+  padding: 1rem;
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.25);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
-.empty { color: var(--color-muted,#9aa0aa); font-style: italic; padding:.75rem; }
-
-.task-list { list-style:none; padding:0; margin:0; display:grid; gap:.5rem; }
-.task {
-  display:grid; grid-template-columns: 28px 1fr auto; gap:.5rem; align-items:start;
-  background: rgba(255,255,255,0.02); border:1px solid var(--color-border,#2a2a32);
-  border-radius:12px; padding:.5rem .6rem;
+.section-card:hover {
+  transform: translateY(-3px);
+  border-color: rgba(155, 135, 245, 0.45);
+  box-shadow: 0 22px 40px rgba(0, 0, 0, 0.3);
 }
-.task.overdue { border-color: rgba(255,120,120,.35); background: rgba(255,80,80,.06); }
-.task.done { opacity:.6; }
-.chk { position:relative; width:24px; height:24px; display:grid; place-items:center; }
-.chk input { position:absolute; opacity:0; width:24px; height:24px; cursor:pointer; }
-.chk .checkmark { width:18px; height:18px; border-radius:6px; border:1px solid var(--color-border,#2a2a32); background: rgba(255,255,255,0.03); }
-.chk input:checked + .checkmark { background: var(--color-thread,#6b6bff); border-color: var(--color-thread,#6b6bff); }
 
-.task-main { display:grid; gap:.25rem; }
-.task-title { font-weight:600; }
-.task-notes { color: var(--color-muted,#9aa0aa); font-size:.9rem; }
-.task-notes.small { font-size:.85rem; }
-.task-actions { display:flex; gap:.5rem; align-items:center; }
-.pill { display:inline-block; font-size:.75rem; padding:.1rem .4rem; border:1px solid var(--color-border,#2a2a32); border-radius:999px; color: var(--color-muted,#9aa0aa); }
-
-.entry-list { list-style:none; padding:0; margin:0; display:grid; gap:.5rem; }
-.entry { display:grid; grid-template-columns: 100px 1fr; gap:.5rem; border:1px dashed var(--color-border,#2a2a32); padding:.5rem .6rem; border-radius:10px; }
-.entry-date { color: var(--color-muted,#9aa0aa); font-size:.9rem; }
-.entry-text { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-
-/* Modal (reuse same styles as ClusterPage modal) */
-.modal-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,.5); display:grid; place-items:center; z-index:1000; }
-.modal { width:min(640px,92vw); background: var(--color-surface,#141418); border:1px solid var(--color-border,#2a2a32); border-radius:14px; box-shadow: 0 20px 60px rgba(0,0,0,.45); padding:.75rem; }
-.modal-head { display:flex; align-items:center; justify-content:space-between; margin-bottom:.5rem; }
-.modal-head h3 { margin:0; font-family: var(--font-glow, ui-sans-serif); }
-.form-grid { display:grid; gap:.6rem; }
-.row { display:grid; grid-template-columns: 1fr 120px 120px; gap:.6rem; }
-.field { display:grid; gap:.3rem; }
-.field span { font-size:.9rem; color: var(--color-muted,#9aa0aa); }
-.field input[type="text"], .field input[type="number"], .field input[type="color"], .field textarea {
-  background: rgba(255,255,255,0.03); border:1px solid var(--color-border,#2a2a32);
-  border-radius:10px; padding:.5rem .6rem; color: inherit;
+.section-card .emoji {
+  font-size: 1.8rem;
 }
-.check { display:flex; gap:.5rem; align-items:center; margin-top:.2rem; }
-.form-error { color:#ff9191; background: rgba(255,145,145,.08); border:1px solid rgba(255,145,145,.3); padding:.4rem .6rem; border-radius:8px; }
-.modal-foot { display:flex; justify-content:flex-end; gap:.5rem; margin-top:.25rem; }
-.btn.icon { background: transparent; border:1px solid var(--color-border,#2a2a32); }
+
+.section-card .card-body h3 {
+  margin: 0 0 0.25rem 0;
+  font-size: 1.1rem;
+  font-family: var(--font-thread, ui-sans-serif);
+}
+
+.section-card .card-body p {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--color-muted, #9aa0aa);
+}
+
+/* Detail */
+.sections-detail {
+  display: grid;
+  gap: 1.25rem;
+  background: var(--color-surface, #141418);
+  border: 1px solid var(--color-border, #2a2a32);
+  border-radius: 20px;
+  padding: 1.25rem clamp(1rem, 3vw, 1.8rem);
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.28);
+}
+
+.sections-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-bottom: 0.85rem;
+  border-bottom: 1px solid var(--color-border, #2a2a32);
+}
+
+.sections-header .title h1 {
+  margin: 0;
+  font-family: var(--font-glow, ui-sans-serif);
+  font-size: clamp(1.4rem, 3vw, 1.8rem);
+}
+
+.sections-header .subtitle {
+  color: var(--color-muted, #9aa0aa);
+  font-size: 0.95rem;
+  margin-top: 0.25rem;
+}
+
+.tab-group {
+  display: inline-flex;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 999px;
+  padding: 0.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.tab-group .tab {
+  border: none;
+  background: transparent;
+  color: var(--color-muted, #9aa0aa);
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.tab-group .tab.active {
+  background: var(--color-thread, #6b6bff);
+  color: var(--color-mist, #fff);
+  box-shadow: 0 8px 18px rgba(107, 107, 255, 0.32);
+}
+
+.tab-group .tab.disabled {
+  opacity: 0.45;
+  pointer-events: none;
+}
+
+.section-summary {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--color-muted, #9aa0aa);
+}
+
+.entries-stack {
+  display: grid;
+  gap: 1rem;
+}
+
+.pages-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.pages-nav {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.page-nav-item {
+  display: grid;
+  grid-template-columns: 28px 1fr;
+  gap: 0.55rem;
+  align-items: center;
+  padding: 0.55rem 0.7rem;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: inherit;
+  text-decoration: none;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.page-nav-item .emoji {
+  font-size: 1.25rem;
+}
+
+.page-nav-item.active {
+  background: rgba(155, 135, 245, 0.18);
+  border-color: rgba(155, 135, 245, 0.4);
+}
+
+.page-nav-item:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.page-chip {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.85rem 1rem;
+  border-radius: 14px;
+  border: 1px solid var(--color-border, #2a2a32);
+  background: var(--color-surface, #141418);
+  color: inherit;
+  text-decoration: none;
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.page-chip:hover {
+  transform: translateY(-2px);
+  border-color: rgba(155, 135, 245, 0.4);
+  box-shadow: 0 16px 30px rgba(0, 0, 0, 0.28);
+}
+
+.page-chip h3 {
+  margin: 0 0 0.15rem 0;
+  font-size: 1rem;
+  font-family: var(--font-thread, ui-sans-serif);
+}
+
+.page-chip span:last-child {
+  font-size: 0.85rem;
+  color: var(--color-muted, #9aa0aa);
+}
+
+.page-chip .emoji {
+  font-size: 1.6rem;
+}
+
+.journal-composer {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.journal-composer textarea {
+  width: 100%;
+  min-height: 140px;
+  border-radius: 14px;
+  border: 1px solid var(--color-border, #2a2a32);
+  background: rgba(255, 255, 255, 0.04);
+  color: inherit;
+  padding: 0.75rem 0.9rem;
+  font-family: inherit;
+  resize: vertical;
+}
+
+.journal-composer textarea:focus {
+  outline: none;
+  border-color: rgba(155, 135, 245, 0.45);
+  box-shadow: 0 0 0 2px rgba(155, 135, 245, 0.25);
+}
+
+.journal-composer-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.motif-stack {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.motif-group {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.motif-group .label {
+  font-size: 0.85rem;
+  color: var(--color-muted, #9aa0aa);
+}
+
+.motif-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.callout {
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(155, 135, 245, 0.3);
+  background: rgba(155, 135, 245, 0.12);
+  color: var(--color-text, #eaeaea);
+}
+
+.callout.error {
+  border-color: rgba(255, 150, 150, 0.4);
+  background: rgba(255, 120, 120, 0.12);
+  color: #ffc7c7;
+}
+
+.loading {
+  padding: 1.5rem 0;
+  color: var(--color-muted, #9aa0aa);
+}
+
+.empty {
+  color: var(--color-muted, #9aa0aa);
+  font-style: italic;
+  padding: 1rem;
+  text-align: center;
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 14px;
+  border: 1px dashed var(--color-border, #2a2a32);
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.75rem;
+  padding: 0.1rem 0.45rem;
+  border: 1px solid var(--color-border, #2a2a32);
+  border-radius: 999px;
+  color: var(--color-muted, #9aa0aa);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.pill-muted {
+  opacity: 0.7;
+}
+
+.sections-rail h3 {
+  margin: 1.25rem 0 0.5rem;
+  font-family: var(--font-thread, ui-sans-serif);
+  font-size: 1rem;
+}
+
+.sections-rail p {
+  margin: 0;
+  color: var(--color-muted, #9aa0aa);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 1280px) {
+  .sections-page {
+    grid-template-columns: var(--sections-sidebar-width) minmax(0, 1fr);
+  }
+
+  .sections-rail {
+    display: none;
+  }
+}
+
+@media (max-width: 960px) {
+  .sections-page {
+    grid-template-columns: minmax(0, 1fr);
+    padding: 1.25rem clamp(0.75rem, 4vw, 1.5rem);
+  }
+
+  .sections-sidebar {
+    position: relative;
+    top: 0;
+    max-height: none;
+    order: -1;
+  }
+}
+
+@media (max-width: 640px) {
+  .sections-hero {
+    padding: 1.5rem;
+  }
+
+  .tab-group {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .tab-group .tab {
+    flex: 1 1 0;
+    text-align: center;
+  }
+}


### PR DESCRIPTION
## Summary
- redesign the sections index/detail page with new layout, tabs, and a tasks rail
- expand the SectionPage styles with responsive navigation, cards, and journal composer elements
- refresh the section page room to reuse the new structure and surface motifs alongside the journal

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d873217260832898573d372487ac3e