### PR TITLE
Add sections search UI and activity endpoint

### DIFF
--- a/frontend/src/pages/SectionsIndex.css
+++ b/frontend/src/pages/SectionsIndex.css
@@ -20,6 +20,71 @@
   margin: 0;
 }
 
+.sections-index__filters {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.sections-index__search-input {
+  width: min(100%, 420px);
+  padding: 0.65rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.05);
+  color: inherit;
+  font: inherit;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.sections-index__search-input:focus {
+  outline: none;
+  border-color: rgba(155, 135, 245, 0.6);
+  background: rgba(155, 135, 245, 0.12);
+}
+
+.sections-index__search-input:disabled {
+  opacity: 0.6;
+}
+
+.sections-index__quick-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.sections-index__filter-button {
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.05);
+  color: inherit;
+  font: inherit;
+  padding: 0.45rem 0.85rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.sections-index__filter-button:hover:not(:disabled) {
+  background: rgba(155, 135, 245, 0.15);
+  border-color: rgba(155, 135, 245, 0.35);
+}
+
+.sections-index__filter-button.is-active {
+  background: rgba(155, 135, 245, 0.22);
+  border-color: rgba(155, 135, 245, 0.6);
+  color: #fff;
+}
+
+.sections-index__filter-button:disabled {
+  opacity: 0.6;
+  cursor: wait;
+}
+
+.sections-index__activity-hint {
+  font-size: 0.85rem;
+}
+
 .sections-index__grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
@@ -80,6 +145,23 @@
   color: var(--color-muted, rgba(200, 205, 214, 0.75));
 }
 
+.sections-index__meta-description {
+  font-size: 0.85rem;
+  line-height: 1.35;
+  color: var(--color-muted, rgba(200, 205, 214, 0.75));
+  max-height: 3.2em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.sections-index__meta-activity {
+  font-size: 0.85rem;
+  color: var(--color-thread, #9b87f5);
+}
+
 .sections-index__actions {
   display: flex;
   justify-content: flex-end;
@@ -127,5 +209,13 @@
 
   .sections-index__grid {
     grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  }
+
+  .sections-index__filters {
+    align-items: stretch;
+  }
+
+  .sections-index__search-input {
+    width: 100%;
   }
 }

--- a/routes/sections.js
+++ b/routes/sections.js
@@ -1,6 +1,9 @@
 // routes/sections.js
 import express from 'express';
+import mongoose from 'mongoose';
+import Entry from '../models/Entry.js';
 import Section from '../models/Section.js';
+import Task from '../models/Task.js';
 
 const router = express.Router();
 
@@ -8,6 +11,38 @@ const ALLOWED_LAYOUTS = new Set(['flow', 'grid', 'kanban', 'tree']);
 
 function getUserId(req) {
   return req.user?.userId || req.user?._id || req.user?.id || null;
+}
+
+function toObjectId(value) {
+  if (!value) return null;
+  if (value instanceof mongoose.Types.ObjectId) return value;
+  if (typeof value === 'string') {
+    if (!mongoose.Types.ObjectId.isValid(value)) return null;
+    return new mongoose.Types.ObjectId(value);
+  }
+  if (value && typeof value === 'object' && value._id) {
+    return toObjectId(value._id);
+  }
+  return null;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function parseWindow(value) {
+  if (value == null) return 7 * DAY_MS;
+  const str = String(value).trim();
+  if (!str) return 7 * DAY_MS;
+
+  const match = str.match(/^(\d+)(?:\s*(d|day|days|h|hour|hours))?$/i);
+  if (!match) return null;
+
+  const amount = Number.parseInt(match[1], 10);
+  if (!Number.isFinite(amount) || amount <= 0) return null;
+
+  const unit = (match[2] || 'd').toLowerCase();
+  const multiplier = unit.startsWith('h') ? 60 * 60 * 1000 : DAY_MS;
+
+  return amount * multiplier;
 }
 
 function sanitizeSlug(str) {
@@ -128,6 +163,107 @@ router.get('/', async (req, res) => {
   } catch (err) {
     console.error('GET /api/sections error:', err);
     res.status(500).json({ error: 'Failed to fetch sections' });
+  }
+});
+
+// GET /api/sections/activity
+router.get('/activity', async (req, res) => {
+  try {
+    const ownerId = getUserId(req);
+    if (!ownerId) return res.status(401).json({ error: 'Unauthorized' });
+
+    const ownerObjectId = toObjectId(ownerId);
+    if (!ownerObjectId) return res.status(400).json({ error: 'Invalid user id' });
+
+    const windowRaw = req.query.window;
+    const windowMs = parseWindow(windowRaw);
+    if (windowMs == null) {
+      return res.status(400).json({ error: 'Invalid window parameter' });
+    }
+
+    const since = new Date(Date.now() - windowMs);
+
+    const sections = await Section.find({ ownerId: ownerObjectId }).select('slug').lean();
+    if (!sections.length) {
+      return res.json({
+        window: { raw: windowRaw ?? '7d', ms: windowMs, since: since.toISOString() },
+        activity: {},
+      });
+    }
+
+    const slugs = sections.map((section) => section.slug).filter(Boolean);
+    if (!slugs.length) {
+      return res.json({
+        window: { raw: windowRaw ?? '7d', ms: windowMs, since: since.toISOString() },
+        activity: {},
+      });
+    }
+
+    const activityMap = Object.create(null);
+    for (const slug of slugs) {
+      activityMap[slug] = { entries: 0, tasks: 0, total: 0 };
+    }
+
+    const entriesActivity = await Entry.aggregate([
+      {
+        $match: {
+          userId: ownerObjectId,
+          section: { $in: slugs },
+          updatedAt: { $gte: since },
+        },
+      },
+      {
+        $group: {
+          _id: '$section',
+          count: { $sum: 1 },
+        },
+      },
+    ]);
+
+    for (const item of entriesActivity) {
+      const slug = item?._id;
+      if (slug && activityMap[slug]) {
+        activityMap[slug].entries = item.count || 0;
+      }
+    }
+
+    const tasksActivity = await Task.aggregate([
+      {
+        $match: {
+          userId: ownerObjectId,
+          sections: { $in: slugs },
+          updatedAt: { $gte: since },
+        },
+      },
+      { $unwind: '$sections' },
+      { $match: { sections: { $in: slugs } } },
+      {
+        $group: {
+          _id: '$sections',
+          count: { $sum: 1 },
+        },
+      },
+    ]);
+
+    for (const item of tasksActivity) {
+      const slug = item?._id;
+      if (slug && activityMap[slug]) {
+        activityMap[slug].tasks = item.count || 0;
+      }
+    }
+
+    for (const slug of Object.keys(activityMap)) {
+      const stats = activityMap[slug];
+      stats.total = (stats.entries || 0) + (stats.tasks || 0);
+    }
+
+    res.json({
+      window: { raw: windowRaw ?? '7d', ms: windowMs, since: since.toISOString() },
+      activity: activityMap,
+    });
+  } catch (err) {
+    console.error('GET /api/sections/activity error:', err);
+    res.status(500).json({ error: 'Failed to fetch section activity' });
   }
 });
 


### PR DESCRIPTION
## Summary
- add a search input, quick filters, and activity hints to the sections index page
- request lightweight activity stats to power the “Most Active” filter
- expose a `/api/sections/activity` endpoint that aggregates entry and task updates per section

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d87f76ffac8328b59062d60c71b5d2