### PR TITLE
Add scoped section theming controls

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,7 +13,8 @@ import RegisterPage from './RegisterPage.jsx';
 import GameList from './GameList.jsx';
 import GamePage from './GamePage.jsx';
 
-import SectionPage from './pages/SectionPage.jsx';            // landing + section detail
+import SectionsIndex from './pages/SectionsIndex.jsx';        // sections index grid
+import SectionPage from './pages/SectionPage.jsx';            // section detail
 import SectionPageRoom from './pages/SectionPageRoom.jsx';    // NEW: page room under a section
 import ClustersIndex from './pages/ClustersIndex.jsx';        // clusters index
 import ClusterRoom from './pages/ClusterRoom.jsx';            // per-cluster room
@@ -68,7 +69,7 @@ function AppRoutes() {
           <Route path="/_adapters" element={<AdapterHarness />} />
 
           {/* Sections */}
-          <Route path="/sections" element={<SectionPage />} />                 {/* landing */}
+          <Route path="/sections" element={<SectionsIndex />} />               {/* landing */}
           <Route path="/sections/:key" element={<SectionPage />} />            {/* section detail */}
           <Route path="/sections/:sectionSlug/:pageSlug" element={<SectionPageRoom />} />             {/* room default -> journal */}
           <Route path="/sections/:sectionSlug/:pageSlug/:tab" element={<SectionPageRoom />} />        {/* room tabbed */}

--- a/frontend/src/adapters/TaskList.default.jsx
+++ b/frontend/src/adapters/TaskList.default.jsx
@@ -127,7 +127,7 @@ export default function TaskList({
     return () => {
       ignore = true;
     };
-  }, [token, targetDate, view]);
+  }, [token, targetDate, view, section, cluster]);
 
   const filtered = useMemo(
     () => filterTasks(tasks, { view, targetDate, section, cluster }),

--- a/frontend/src/pages/SectionPage.css
+++ b/frontend/src/pages/SectionPage.css
@@ -1,110 +1,746 @@
 /* frontend/src/pages/SectionPage.css */
+:root {
+  --sections-sidebar-width: 260px;
+  --sections-rail-width: 320px;
+}
+
 .sections-page {
-  display: grid; grid-template-columns: 260px 1fr;
+  display: grid;
+  grid-template-columns: var(--sections-sidebar-width) minmax(0, 1fr) var(--sections-rail-width);
+  gap: 1.5rem;
+  padding: 1.5rem clamp(1rem, 3vw, 2.25rem);
   min-height: calc(100vh - 64px);
-  background: var(--color-background, #0f0f12);
-  color: var(--color-text, #eaeaea);
+  box-sizing: border-box;
+  background: var(--section-surface, #0f1119);
+  color: #f6f6fb;
+}
+
+.sections-sidebar,
+.sections-rail {
+  background: var(--section-surface-elevated, #161926);
+  border: 1px solid var(--section-border, rgba(255, 255, 255, 0.1));
+  border-radius: calc(var(--section-radius, 18px) + 4px);
+  box-shadow: var(--section-shadow, 0 18px 40px rgba(0, 0, 0, 0.32));
+  padding: 1.1rem;
+  position: sticky;
+  top: 80px;
+  max-height: calc(100vh - 96px);
+  overflow: auto;
+  align-self: start;
+  display: grid;
+  gap: 1rem;
+}
+
+.sections-main {
+  display: grid;
+  gap: 1.5rem;
+  align-content: start;
 }
 
 /* Sidebar */
-.sections-sidebar {
-  border-right: 1px solid var(--color-border, #2a2a32);
-  padding: 1rem; position: sticky; top: 64px; align-self: start;
-  height: calc(100vh - 64px); overflow: auto; background: var(--color-surface, #141418);
+.sidebar-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
 }
-.sidebar-head { display:flex; align-items:center; justify-content:space-between; }
-.sidebar-head h2 { margin:0 0 .75rem 0; font-family: var(--font-glow, ui-sans-serif); font-size:1.1rem; color: #a8e4ff; }
-.section-list { margin:0; padding:0; list-style:none; display:grid; gap:.25rem; }
-.section-item { border-radius: 10px; }
-.section-link {
-  display:grid; grid-template-columns: 12px 24px 1fr; gap:.5rem; align-items:center;
-  padding:.5rem .6rem; border-radius:10px; text-decoration:none; color:inherit;
-}
-.section-link:hover { background: rgba(255,255,255,0.04); }
-.section-item.active .section-link { background: rgba(92,194,255,0.16); outline:1px solid rgba(92,194,255,0.35); }
-.color-dot { width:12px; height:12px; border-radius:50%; border:1px solid rgba(0,0,0,.2); }
-.icon { font-size:1rem; filter: saturate(1.2); }
-.label { font-family: var(--font-thread, ui-sans-serif); }
 
-/* Main */
-.sections-main { padding: 1rem 1.25rem 3rem; }
-.sections-header {
-  display:flex; align-items:center; justify-content:space-between;
-  border-bottom: 1px solid var(--color-border, #2a2a32);
-  padding-bottom:.75rem; margin-bottom:1rem;
+.sidebar-head h2 {
+  margin: 0;
+  font-family: var(--font-glow, ui-sans-serif);
+  font-size: 1.2rem;
+  color: var(--section-accent, #c8b6ff);
 }
-.sections-header .title h1 { margin:0; font-family: var(--font-glow, ui-sans-serif); font-size:1.5rem; }
-.sections-header .subtitle { color: var(--color-muted,#9aa0aa); font-size:.9rem; margin-top:.25rem; }
 
-.controls { display:flex; gap:.5rem; align-items:center; }
+.sidebar-count {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.58);
+}
+
+.section-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.section-item .section-link {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 14px 28px 1fr;
+  gap: 0.6rem;
+  align-items: center;
+  padding: 0.55rem 0.65rem;
+  border-radius: calc(var(--section-radius, 18px) - 6px);
+  border: 1px solid transparent;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+  font-size: 0.95rem;
+  transition: background 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
+}
+
+.section-item .section-link:hover {
+  background: var(--section-accent-soft, rgba(200, 182, 255, 0.16));
+}
+
+.section-item.active .section-link {
+  background: var(--section-primary-soft, rgba(107, 107, 255, 0.2));
+  border-color: var(--section-primary, #6b6bff);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
+}
+
+.section-item .color-dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 1px solid rgba(0, 0, 0, 0.35);
+  background: currentColor;
+}
+
+.section-item .icon {
+  font-size: 1.1rem;
+}
+
+.section-item .label {
+  font-family: var(--font-thread, ui-sans-serif);
+  letter-spacing: 0.01em;
+}
+
+/* Landing */
+.sections-landing {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.sections-hero {
+  background: var(--section-primary-soft, rgba(107, 107, 255, 0.2));
+  border: 1px solid rgba(107, 107, 255, 0.45);
+  border-radius: calc(var(--section-radius, 18px) + 6px);
+  padding: 2rem clamp(1.3rem, 3vw, 2.75rem);
+  box-shadow: var(--section-shadow, 0 20px 44px rgba(0, 0, 0, 0.32));
+}
+
+.sections-hero h1 {
+  margin: 0 0 0.75rem 0;
+  font-family: var(--font-glow, ui-sans-serif);
+  font-size: clamp(1.5rem, 3vw, 2rem);
+}
+
+.sections-hero p {
+  margin: 0;
+  font-size: 1rem;
+  color: rgba(255, 255, 255, 0.7);
+  max-width: 42ch;
+}
+
+/* Detail hero */
+.section-hero {
+  display: grid;
+  gap: 1.25rem;
+  background: var(--section-surface-elevated, #161926);
+  border: 1px solid var(--section-border, rgba(255, 255, 255, 0.1));
+  border-radius: calc(var(--section-radius, 18px) + 8px);
+  padding: 1.5rem clamp(1.2rem, 3vw, 2.4rem);
+  box-shadow: var(--section-shadow, 0 22px 48px rgba(0, 0, 0, 0.34));
+}
+
+.section-identity {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.section-icon {
+  width: 64px;
+  height: 64px;
+  border-radius: calc(var(--section-radius, 18px) - 4px);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: var(--section-primary-soft, rgba(107, 107, 255, 0.22));
+  font-size: 2rem;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.section-icon:hover {
+  transform: translateY(-2px) scale(1.02);
+}
+
+.section-title-group {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.section-title-input {
+  font-size: clamp(1.6rem, 4vw, 2.2rem);
+  font-family: var(--font-glow, ui-sans-serif);
+  border: none;
+  background: transparent;
+  color: inherit;
+  padding: 0;
+  margin: 0;
+}
+
+.section-title-input:focus {
+  outline: none;
+  box-shadow: inset 0 -2px 0 0 var(--section-primary, #6b6bff);
+}
+
+.section-updated {
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.section-description textarea {
+  width: 100%;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: var(--section-radius, 18px);
+  padding: 0.9rem 1rem;
+  color: inherit;
+  font-size: 1rem;
+  resize: vertical;
+  min-height: 84px;
+}
+
+.section-description textarea:focus {
+  outline: none;
+  border-color: var(--section-primary, #6b6bff);
+  box-shadow: 0 0 0 2px rgba(107, 107, 255, 0.25);
+}
+
+.section-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  align-items: center;
+}
+
+.layout-picker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.layout-pill {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 999px;
+  color: inherit;
+  padding: 0.4rem 0.9rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, background 0.15s ease;
+}
+
+.layout-pill:hover {
+  transform: translateY(-1px);
+}
+
+.layout-pill.active {
+  background: var(--section-primary, #6b6bff);
+  border-color: var(--section-primary, #6b6bff);
+}
+
+.theme-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  background: var(--section-accent-soft, rgba(200, 182, 255, 0.18));
+  border: 1px solid rgba(200, 182, 255, 0.4);
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+  color: inherit;
+}
+
+.theme-chip .dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--section-primary, #6b6bff);
+}
+
+.public-toggle {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 999px;
+  padding: 0.2rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  cursor: pointer;
+  color: inherit;
+}
+
+.public-toggle.is-public {
+  background: var(--section-primary, #6b6bff);
+  border-color: var(--section-primary, #6b6bff);
+}
+
+.public-toggle .toggle-thumb {
+  display: inline-block;
+  width: 26px;
+  height: 26px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.85);
+}
+
+.section-subnav {
+  display: flex;
+  gap: 0.75rem;
+  position: sticky;
+  top: 72px;
+  background: rgba(15, 17, 25, 0.85);
+  backdrop-filter: blur(10px);
+  padding: 0.35rem 0.5rem;
+  border-radius: 999px;
+  z-index: 5;
+}
+
+.subnav-link {
+  color: rgba(255, 255, 255, 0.65);
+  text-decoration: none;
+  font-size: 0.95rem;
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.subnav-link:hover,
+.subnav-link:focus {
+  background: var(--section-primary-soft, rgba(107, 107, 255, 0.22));
+  color: #fff;
+}
+
+.section-panel {
+  background: rgba(18, 20, 30, 0.7);
+  border: 1px solid var(--section-border, rgba(255, 255, 255, 0.1));
+  border-radius: calc(var(--section-radius, 18px) + 4px);
+  padding: 1.5rem clamp(1.1rem, 3vw, 2.2rem);
+  box-shadow: var(--section-shadow, 0 18px 40px rgba(0, 0, 0, 0.3));
+  display: grid;
+  gap: 1rem;
+}
+
+.section-panel header h2 {
+  margin: 0;
+  font-family: var(--font-thread, ui-sans-serif);
+  font-size: 1.3rem;
+}
+
+.section-panel header .muted {
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.modules-placeholder .empty {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px dashed rgba(255, 255, 255, 0.16);
+  border-radius: var(--section-radius, 18px);
+  padding: 2rem clamp(1rem, 3vw, 2.6rem);
+  text-align: center;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.modules-placeholder .cta {
+  background: var(--section-primary, #6b6bff);
+  border: none;
+  border-radius: 999px;
+  padding: 0.6rem 1.4rem;
+  color: #fff;
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+.entries-stack {
+  display: grid;
+  gap: 1rem;
+}
+
+.entries-stack .empty {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: var(--section-radius, 18px);
+  padding: 1.5rem;
+  text-align: center;
+}
+
+.entry-card {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: calc(var(--section-radius, 18px) - 2px);
+  padding: 1.1rem;
+  display: grid;
+  gap: 0.75rem;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.08);
+}
+
+.entry-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.entry-card .pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 999px;
+  padding: 0.2rem 0.6rem;
+  font-size: 0.8rem;
+  color: inherit;
+}
+
+.entry-card .pill-muted {
+  opacity: 0.7;
+}
+
+.entry-text {
+  line-height: 1.6;
+}
+
+.tasks-panel {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: var(--section-radius, 18px);
+  padding: 1rem;
+}
+
+.sections-rail {
+  gap: 1.5rem;
+}
+
+.motif-stack {
+  display: grid;
+  gap: 0.8rem;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: var(--section-radius, 18px);
+  padding: 1.1rem;
+}
+
+.motif-group {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.motif-group .label {
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.motif-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.motif-pills .pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 999px;
+  padding: 0.25rem 0.7rem;
+  font-size: 0.85rem;
+}
+
 .btn {
-  background: var(--color-thread, #6b6bff); color: var(--color-mist, #fff);
-  border:none; border-radius:10px; padding:.5rem .7rem; cursor:pointer;
-  box-shadow: 0 2px 8px rgba(0,0,0,.2);
-}
-.btn:hover { filter: brightness(1.05); }
-.btn.ghost { background: transparent; color: #a8e4ff; border:1px solid var(--color-border,#2a2a32); }
-.btn.sm { padding:.25rem .5rem; font-size:.85rem; }
-
-.toast { margin:.75rem 0 0; background: rgba(100,255,200,.08); border:1px solid rgba(100,255,200,.25); padding:.5rem .75rem; border-radius:8px; font-size:.9rem; }
-.loading { display:grid; place-items:center; padding:2rem 0; }
-.spin { width:26px; height:26px; border-radius:50%; border:3px solid rgba(255,255,255,.15); border-top-color:#a8e4ff; animation: spin .9s linear infinite; }
-@keyframes spin { to { transform: rotate(360deg); } }
-
-.grid { display:grid; gap:1rem; grid-template-columns: repeat(2, minmax(0,1fr)); }
-.section { background: var(--color-surface, #141418); border:1px solid var(--color-border,#2a2a32); border-radius:14px; padding:.75rem; box-shadow:0 8px 20px rgba(0,0,0,.2); }
-.section-head { display:flex; align-items:center; justify-content:space-between; border-bottom:1px solid var(--color-border,#2a2a32); padding-bottom:.5rem; margin-bottom:.5rem; }
-.section-head h3 { margin:0; font-family: var(--font-glow, ui-sans-serif); font-size:1.05rem; color:#cfefff; }
-.hint { color: var(--color-muted,#9aa0aa); font-size:.85rem; }
-
-.quick-add { display:flex; gap:.4rem; align-items:center; }
-.quick-add input {
-  background: rgba(255,255,255,0.03);
-  border: 1px solid var(--color-border, #2a2a32);
-  border-radius: 10px; padding: .35rem .55rem; color: inherit; min-width: 220px;
+  background: var(--section-primary, #6b6bff);
+  color: #fff;
+  border: none;
+  border-radius: 12px;
+  padding: 0.45rem 0.85rem;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+  transition: filter 0.2s ease, transform 0.2s ease;
 }
 
-.empty { color: var(--color-muted,#9aa0aa); font-style: italic; padding:.75rem; }
-
-.task-list { list-style:none; padding:0; margin:0; display:grid; gap:.5rem; }
-.task {
-  display:grid; grid-template-columns: 28px 1fr auto; gap:.5rem; align-items:start;
-  background: rgba(255,255,255,0.02); border:1px solid var(--color-border,#2a2a32);
-  border-radius:12px; padding:.5rem .6rem;
+.btn:hover {
+  filter: brightness(1.05);
+  transform: translateY(-1px);
 }
-.task.overdue { border-color: rgba(255,120,120,.35); background: rgba(255,80,80,.06); }
-.task.done { opacity:.6; }
-.chk { position:relative; width:24px; height:24px; display:grid; place-items:center; }
-.chk input { position:absolute; opacity:0; width:24px; height:24px; cursor:pointer; }
-.chk .checkmark { width:18px; height:18px; border-radius:6px; border:1px solid var(--color-border,#2a2a32); background: rgba(255,255,255,0.03); }
-.chk input:checked + .checkmark { background: var(--color-thread,#6b6bff); border-color: var(--color-thread,#6b6bff); }
 
-.task-main { display:grid; gap:.25rem; }
-.task-title { font-weight:600; }
-.task-notes { color: var(--color-muted,#9aa0aa); font-size:.9rem; }
-.task-notes.small { font-size:.85rem; }
-.task-actions { display:flex; gap:.5rem; align-items:center; }
-.pill { display:inline-block; font-size:.75rem; padding:.1rem .4rem; border:1px solid var(--color-border,#2a2a32); border-radius:999px; color: var(--color-muted,#9aa0aa); }
-
-.entry-list { list-style:none; padding:0; margin:0; display:grid; gap:.5rem; }
-.entry { display:grid; grid-template-columns: 100px 1fr; gap:.5rem; border:1px dashed var(--color-border,#2a2a32); padding:.5rem .6rem; border-radius:10px; }
-.entry-date { color: var(--color-muted,#9aa0aa); font-size:.9rem; }
-.entry-text { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-
-/* Modal (reuse same styles as ClusterPage modal) */
-.modal-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,.5); display:grid; place-items:center; z-index:1000; }
-.modal { width:min(640px,92vw); background: var(--color-surface,#141418); border:1px solid var(--color-border,#2a2a32); border-radius:14px; box-shadow: 0 20px 60px rgba(0,0,0,.45); padding:.75rem; }
-.modal-head { display:flex; align-items:center; justify-content:space-between; margin-bottom:.5rem; }
-.modal-head h3 { margin:0; font-family: var(--font-glow, ui-sans-serif); }
-.form-grid { display:grid; gap:.6rem; }
-.row { display:grid; grid-template-columns: 1fr 120px 120px; gap:.6rem; }
-.field { display:grid; gap:.3rem; }
-.field span { font-size:.9rem; color: var(--color-muted,#9aa0aa); }
-.field input[type="text"], .field input[type="number"], .field input[type="color"], .field textarea {
-  background: rgba(255,255,255,0.03); border:1px solid var(--color-border,#2a2a32);
-  border-radius:10px; padding:.5rem .6rem; color: inherit;
+.btn.ghost {
+  background: transparent;
+  color: rgba(255, 255, 255, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.2);
 }
-.check { display:flex; gap:.5rem; align-items:center; margin-top:.2rem; }
-.form-error { color:#ff9191; background: rgba(255,145,145,.08); border:1px solid rgba(255,145,145,.3); padding:.4rem .6rem; border-radius:8px; }
-.modal-foot { display:flex; justify-content:flex-end; gap:.5rem; margin-top:.25rem; }
-.btn.icon { background: transparent; border:1px solid var(--color-border,#2a2a32); }
+
+.btn.primary {
+  background: var(--section-primary, #6b6bff);
+  color: #fff;
+}
+
+.btn.sm {
+  padding: 0.35rem 0.6rem;
+  font-size: 0.85rem;
+}
+
+.section-metadata {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.section-metadata div {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.section-metadata dt {
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.section-metadata dd {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.theme-editor {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1.5rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.theme-editor-head {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.theme-editor-head h3 {
+  margin: 0;
+  font-size: 1.15rem;
+  font-family: var(--font-thread, ui-sans-serif);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.8rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  background: var(--section-primary-soft, rgba(107, 107, 255, 0.2));
+  border: 1px solid rgba(107, 107, 255, 0.4);
+  color: inherit;
+}
+
+.theme-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.theme-field {
+  display: grid;
+  gap: 0.4rem;
+  align-content: start;
+}
+
+.theme-field span {
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.theme-field input[type="color"] {
+  width: 100%;
+  height: 44px;
+  border-radius: calc(var(--section-radius, 18px) - 6px);
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  background: transparent;
+  cursor: pointer;
+}
+
+.theme-field input[type="range"] {
+  width: 100%;
+}
+
+.theme-field output {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.theme-field input[type="text"] {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: calc(var(--section-radius, 18px) - 4px);
+  padding: 0.55rem 0.75rem;
+  color: inherit;
+  font-family: inherit;
+}
+
+.theme-field-wide {
+  grid-column: span 2;
+}
+
+.theme-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+/* Section rooms */
+.sections-page.sections-room {
+  grid-template-columns: var(--sections-sidebar-width) minmax(0, 1fr) var(--sections-rail-width);
+}
+
+.sections-room .sections-detail {
+  display: grid;
+  gap: 1.25rem;
+  background: rgba(18, 20, 30, 0.7);
+  border: 1px solid var(--section-border, rgba(255, 255, 255, 0.1));
+  border-radius: calc(var(--section-radius, 18px) + 4px);
+  padding: 1.5rem clamp(1.1rem, 3vw, 2.3rem);
+  box-shadow: var(--section-shadow, 0 18px 40px rgba(0, 0, 0, 0.32));
+}
+
+.sections-room .sections-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+  border-bottom: 1px solid var(--section-border, rgba(255, 255, 255, 0.1));
+  padding-bottom: 0.75rem;
+}
+
+.sections-room .sections-header .title h1 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-family: var(--font-glow, ui-sans-serif);
+}
+
+.sections-room .sections-header .subtitle {
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.9rem;
+  margin-top: 0.35rem;
+}
+
+.sections-room .tab-group {
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.sections-room .tab-group .tab {
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  color: inherit;
+  text-decoration: none;
+  font-size: 0.95rem;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.sections-room .tab-group .tab.disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.sections-room .tab-group .tab:hover,
+.sections-room .tab-group .tab.active {
+  background: var(--section-primary, #6b6bff);
+  border-color: var(--section-primary, #6b6bff);
+}
+
+.journal-composer {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: var(--section-radius, 18px);
+  padding: 1rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.journal-composer textarea {
+  width: 100%;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: calc(var(--section-radius, 18px) - 4px);
+  padding: 0.9rem 1rem;
+  color: inherit;
+  resize: vertical;
+  min-height: 120px;
+}
+
+.journal-composer textarea:focus {
+  outline: none;
+  border-color: var(--section-primary, #6b6bff);
+  box-shadow: 0 0 0 2px rgba(107, 107, 255, 0.25);
+}
+
+.journal-composer .journal-composer-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.journal-composer .button {
+  background: var(--section-primary, #6b6bff);
+  color: #fff;
+  border: none;
+  border-radius: 999px;
+  padding: 0.5rem 1.3rem;
+  cursor: pointer;
+  transition: filter 0.2s ease, transform 0.2s ease;
+}
+
+.journal-composer .button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+@media (max-width: 1200px) {
+  .sections-page,
+  .sections-page.sections-room {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .sections-sidebar,
+  .sections-rail {
+    position: static;
+    max-height: none;
+  }
+
+  .sections-sidebar {
+    order: 1;
+  }
+
+  .sections-rail {
+    order: 3;
+  }
+
+  .sections-main {
+    order: 2;
+  }
+}
+
+@media (max-width: 780px) {
+  .section-controls,
+  .sections-room .sections-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .section-subnav {
+    position: static;
+    margin-top: -0.5rem;
+  }
+}

--- a/frontend/src/pages/SectionPage.jsx
+++ b/frontend/src/pages/SectionPage.jsx
@@ -1,184 +1,721 @@
 // frontend/src/pages/SectionPage.jsx
-import { useParams } from 'react-router-dom';
-import { useState, useEffect, useContext, useMemo } from 'react';
+import { useState, useEffect, useContext, useMemo, useCallback } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 import axios from '../api/axiosInstance.js';
 import { AuthContext } from '../AuthContext.jsx';
 import TaskList from '../adapters/TaskList.default.jsx';
-import '../Main.css';
 import SafeHTML from '../components/SafeHTML.jsx';
+import '../Main.css';
+import './SectionPage.css';
+
+const LAYOUT_OPTIONS = [
+  { value: 'flow', label: 'Flow' },
+  { value: 'grid', label: 'Grid' },
+  { value: 'kanban', label: 'Kanban' },
+  { value: 'tree', label: 'Tree' },
+];
+
+const SUBNAV_LINKS = [
+  { id: 'overview', label: 'Overview' },
+  { id: 'entries', label: 'Entries' },
+  { id: 'tasks', label: 'Tasks' },
+  { id: 'settings', label: 'Settings' },
+];
+
+const DEFAULT_THEME = {
+  primary: '#6b6bff',
+  surface: '#141418',
+  accent: '#c8b6ff',
+  radius: 18,
+  shadow: '0 20px 44px rgba(0, 0, 0, 0.32)',
+};
+
+function isColorString(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function clampRadius(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) return Math.min(40, Math.max(0, value));
+  const parsed = parseFloat(value);
+  if (Number.isNaN(parsed)) return DEFAULT_THEME.radius;
+  return Math.min(40, Math.max(0, parsed));
+}
+
+function normalizeTheme(raw) {
+  const theme = raw && typeof raw === 'object' ? raw : {};
+  return {
+    primary: isColorString(theme.primary) ? theme.primary : DEFAULT_THEME.primary,
+    surface: isColorString(theme.surface) ? theme.surface : DEFAULT_THEME.surface,
+    accent: isColorString(theme.accent) ? theme.accent : DEFAULT_THEME.accent,
+    radius: clampRadius(theme.radius ?? DEFAULT_THEME.radius),
+    shadow: typeof theme.shadow === 'string' && theme.shadow.trim()
+      ? theme.shadow
+      : DEFAULT_THEME.shadow,
+  };
+}
+
+function hexToRgb(hex) {
+  if (typeof hex !== 'string') return null;
+  const value = hex.trim();
+  if (!value.startsWith('#')) return null;
+  const normalized = value.slice(1);
+  if (![3, 6].includes(normalized.length)) return null;
+  const expand = normalized.length === 3 ? normalized.split('').map((c) => c + c).join('') : normalized;
+  const int = parseInt(expand, 16);
+  if (Number.isNaN(int)) return null;
+  const r = (int >> 16) & 255;
+  const g = (int >> 8) & 255;
+  const b = int & 255;
+  return { r, g, b };
+}
+
+function rgbaFromColor(value, alpha) {
+  const rgb = hexToRgb(value);
+  if (rgb) {
+    return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${alpha})`;
+  }
+  return value;
+}
+
+function mixWithWhite(value, ratio = 0.15) {
+  const rgb = hexToRgb(value);
+  if (!rgb) return value;
+  const clampRatio = Math.min(1, Math.max(0, ratio));
+  const mix = (channel) => Math.round(channel + (255 - channel) * clampRatio);
+  return `rgb(${mix(rgb.r)}, ${mix(rgb.g)}, ${mix(rgb.b)})`;
+}
+
+function themeToCssVars(theme) {
+  const normalized = normalizeTheme(theme);
+  return {
+    '--section-primary': normalized.primary,
+    '--section-primary-soft': rgbaFromColor(normalized.primary, 0.2),
+    '--section-surface': normalized.surface,
+    '--section-surface-elevated': mixWithWhite(normalized.surface, 0.08),
+    '--section-accent': normalized.accent,
+    '--section-accent-soft': rgbaFromColor(normalized.accent, 0.24),
+    '--section-radius': `${normalized.radius}px`,
+    '--section-shadow': normalized.shadow,
+    '--section-border': mixWithWhite(normalized.surface, 0.3),
+  };
+}
+
+function sortEntries(entries = []) {
+  const list = Array.isArray(entries) ? [...entries] : [];
+  return list.sort((a, b) => {
+    const aKey = a?.createdAt || a?.updatedAt || `${a?.date ?? ''}T00:00:00`;
+    const bKey = b?.createdAt || b?.updatedAt || `${b?.date ?? ''}T00:00:00`;
+    return aKey > bKey ? -1 : aKey < bKey ? 1 : 0;
+  });
+}
+
+function renderEntryHtml(entry) {
+  if (entry?.html && entry.html.trim()) return entry.html;
+  if (typeof entry?.content === 'string' && /<[^>]+>/.test(entry.content)) return entry.content;
+  return (entry?.text ?? '').replace(/\n/g, '<br/>');
+}
+
+function normalizeSection(raw) {
+  if (!raw) return null;
+  const slug = (raw.slug || raw.key || '').toLowerCase();
+  if (!slug) return null;
+  return {
+    ...raw,
+    id: raw.id || raw._id,
+    slug,
+    key: slug,
+    title: raw.title || raw.label || raw.name || 'Untitled section',
+    icon: raw.icon || raw.emoji || '📚',
+    description: typeof raw.description === 'string' ? raw.description : '',
+    layout: raw.layout || 'flow',
+    theme: normalizeTheme(raw.theme),
+    public: Boolean(raw.public),
+    color: raw.color || raw.themeColor || 'var(--color-thread, #6b6bff)',
+    tagline: raw.tagline || raw.subtitle || '',
+    summary: raw.summary || raw.description || '',
+    updatedAt: raw.updatedAt || raw.updated_at || null,
+    createdAt: raw.createdAt || raw.created_at || null,
+  };
+}
 
 export default function SectionPage() {
+  const navigate = useNavigate();
   const params = useParams();
-  // Accept either /sections/:key (new) or /sections/:sectionName (old)
-  const sectionKey = (params.key || params.sectionName || '').toLowerCase();
-
+  const initialKey = (params.key || params.sectionName || '').toLowerCase();
   const { token } = useContext(AuthContext);
-  const [entries, setEntries] = useState([]);
-  const [pages, setPages] = useState([]);
-  const [allSections, setAllSections] = useState([]);
-  const [loading, setLoading] = useState(true);
 
-  // entries-first filter toggles (default: entries on)
-  const [showEntries, setShowEntries] = useState(true);
+  const [sections, setSections] = useState([]);
+  const [entries, setEntries] = useState([]);
+  const [loadingSections, setLoadingSections] = useState(true);
+  const [loadingEntries, setLoadingEntries] = useState(false);
+  const [fetchError, setFetchError] = useState('');
+  const [saveError, setSaveError] = useState('');
+  const [activeKey, setActiveKey] = useState(initialKey);
+  const [draft, setDraft] = useState(null);
+  const [updating, setUpdating] = useState({});
+  const [themeDraft, setThemeDraft] = useState(DEFAULT_THEME);
+  const [themeDirty, setThemeDirty] = useState(false);
 
   useEffect(() => {
-    let cancelled = false;
+    setActiveKey(initialKey);
+  }, [initialKey]);
 
-    async function run() {
-      setLoading(true);
+  useEffect(() => {
+    if (!token) {
+      setSections([]);
+      setEntries([]);
+      setDraft(null);
+      setLoadingSections(false);
+      setLoadingEntries(false);
+    }
+  }, [token]);
+
+  useEffect(() => {
+    if (!token) return;
+    let ignore = false;
+
+    async function loadSections() {
+      setLoadingSections(true);
       try {
-        // Always fetch the list so landing can render something when no key
-        const sec = await axios.get('/api/sections');
-        if (!cancelled) setAllSections(Array.isArray(sec.data) ? sec.data : []);
-
-        if (!sectionKey) return; // landing mode only
-
-        // Entries for this section
-        const entryRes = await axios.get(`/api/entries?section=${encodeURIComponent(sectionKey)}&limit=100`);
-        if (!cancelled) setEntries(Array.isArray(entryRes.data) ? entryRes.data : []);
-
-        // Custom pages for this section
-        const pagesRes = await axios.get(`/api/section-pages/by-section/${encodeURIComponent(sectionKey)}`);
-        const rawPages = Array.isArray(pagesRes.data?.items)
-          ? pagesRes.data.items
-          : Array.isArray(pagesRes.data)
-            ? pagesRes.data
-            : [];
-        const normalizedPages = rawPages.map((p) => ({
-          _id: p._id || p.id,
-          slug: p.slug || '',
-          title: p.title || p.name || 'Untitled page',
-          icon: p.icon || p.emoji || '📄',
-        })).filter((p) => p._id && p.slug);
-        if (!cancelled) setPages(normalizedPages);
-      } catch (e) {
-        console.warn('SectionPage fetch error:', e?.response?.data || e.message);
-        if (!cancelled) {
-          if (!sectionKey) setAllSections([]);
-          setEntries([]);
-          setPages([]);
-        }
+        const res = await axios.get('/api/sections');
+        if (ignore) return;
+        const list = Array.isArray(res.data) ? res.data : [];
+        const normalized = list.map(normalizeSection).filter(Boolean);
+        setSections(normalized);
+        setFetchError('');
+      } catch (err) {
+        if (ignore) return;
+        console.warn('Section list failed:', err?.response?.data || err.message);
+        setSections([]);
+        setFetchError(err?.response?.data?.error || 'Failed to load sections');
       } finally {
-        if (!cancelled) setLoading(false);
+        if (!ignore) setLoadingSections(false);
       }
     }
 
-    if (token) run();
-    return () => { cancelled = true; };
-  }, [token, sectionKey]);
+    loadSections();
+    return () => {
+      ignore = true;
+    };
+  }, [token]);
 
-  const title = sectionKey ? sectionKey.replace(/-/g, ' ') : 'Sections';
+  const activeSection = useMemo(() => {
+    if (!activeKey) return null;
+    return sections.find((s) => s.key === activeKey) || null;
+  }, [sections, activeKey]);
 
-  const sortedSections = useMemo(() => {
-    return (allSections || [])
-      .map(s => ({
-        key: s.key || s.slug || '',
-        label: s.label || s.name || s.key || '',
-        emoji: s.icon || s.emoji || '📚',
-        pinned: !!s.pinned,
-        order: Number.isFinite(s.order) ? s.order : 0,
-      }))
-      .filter(s => s.key)
-      .sort((a,b) => (a.pinned !== b.pinned) ? (a.pinned ? -1:1) : (a.order - b.order) || a.label.localeCompare(b.label));
-  }, [allSections]);
+  useEffect(() => {
+    if (!activeSection && sections.length > 0 && !loadingSections) {
+      const fallback = sections[0];
+      setActiveKey(fallback?.key || '');
+      if (fallback?.key) {
+        navigate(`/sections/${encodeURIComponent(fallback.key)}`, { replace: true });
+      }
+    }
+  }, [activeSection, sections, loadingSections, navigate]);
 
-  if (!sectionKey) {
-    // Landing view
-    return (
-      <div className="page">
-        <div className="card" style={{ marginBottom: 16 }}>
-          <div className="section-header" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
-            <h2 style={{ margin: 0 }}>{title}</h2>
-          </div>
-          {loading ? (
-            <div>Loading…</div>
-          ) : sortedSections.length === 0 ? (
-            <p className="muted">No sections yet. Create one in the Clusters view or via API.</p>
-          ) : (
-            <ul className="unstyled" style={{ columns: 2, columnGap: 16, maxWidth: 720 }}>
-              {sortedSections.map(s => (
-                <li key={s.key} style={{ breakInside: 'avoid', marginBottom: 8 }}>
-                  <a href={`/sections/${encodeURIComponent(s.key)}`} className="link">
-                    <span style={{ marginRight: 6 }}>{s.emoji}</span>{s.label}
-                  </a>
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
-      </div>
-    );
-  }
+  useEffect(() => {
+    if (activeSection) {
+      setDraft({
+        id: activeSection.id,
+        key: activeSection.key,
+        title: activeSection.title,
+        icon: activeSection.icon,
+        description: activeSection.description,
+        layout: activeSection.layout,
+        theme: normalizeTheme(activeSection.theme),
+        public: activeSection.public,
+      });
+      setThemeDraft(normalizeTheme(activeSection.theme));
+      setThemeDirty(false);
+      setSaveError('');
+    } else {
+      setDraft(null);
+      setThemeDraft(DEFAULT_THEME);
+      setThemeDirty(false);
+    }
+  }, [activeSection]);
 
-  // Detail view
+  useEffect(() => {
+    if (!token || !activeSection) {
+      setEntries([]);
+      return;
+    }
+
+    let ignore = false;
+
+    async function loadEntries() {
+      setLoadingEntries(true);
+      try {
+        const res = await axios.get(`/api/entries?section=${encodeURIComponent(activeSection.slug)}&limit=100`);
+        if (ignore) return;
+        const list = Array.isArray(res.data) ? res.data : [];
+        setEntries(list);
+      } catch (err) {
+        if (ignore) return;
+        console.warn('Section entries failed:', err?.response?.data || err.message);
+        setEntries([]);
+      } finally {
+        if (!ignore) setLoadingEntries(false);
+      }
+    }
+
+    loadEntries();
+    return () => {
+      ignore = true;
+    };
+  }, [token, activeSection]);
+
+  const sortedEntries = useMemo(() => sortEntries(entries), [entries]);
+
+  const handleSelectSection = useCallback(
+    (section) => {
+      if (!section?.key) return;
+      setActiveKey(section.key);
+      navigate(`/sections/${encodeURIComponent(section.key)}`);
+    },
+    [navigate],
+  );
+
+  const handleUpdate = useCallback(
+    async (patch) => {
+      if (!activeSection?.id || !patch || Object.keys(patch).length === 0) return false;
+      const keys = Object.keys(patch);
+      const snapshot = activeSection;
+      setUpdating((prev) => {
+        const next = { ...prev };
+        keys.forEach((key) => {
+          next[key] = true;
+        });
+        return next;
+      });
+      setSaveError('');
+      try {
+        const res = await axios.put(`/api/sections/${activeSection.id}`, patch);
+        const updated = normalizeSection(res.data);
+        if (updated) {
+          setSections((prev) => prev.map((s) => (s.id === updated.id ? updated : s)));
+          setDraft((prev) => (prev ? { ...prev, ...updated } : prev));
+          return true;
+        }
+      } catch (err) {
+        console.warn('Update section failed:', err?.response?.data || err.message);
+        setSaveError(err?.response?.data?.error || 'Unable to save section changes');
+        setDraft((prev) => {
+          if (!prev) return prev;
+          const next = { ...prev };
+          keys.forEach((key) => {
+            next[key] = snapshot[key];
+          });
+          return next;
+        });
+        return false;
+      } finally {
+        setUpdating((prev) => {
+          const next = { ...prev };
+          keys.forEach((key) => {
+            delete next[key];
+          });
+          return next;
+        });
+      }
+      return false;
+    },
+    [activeSection],
+  );
+
+  const handleIconChange = useCallback(() => {
+    if (!draft) return;
+    const nextIcon = window.prompt('Choose an emoji or short icon for this section', draft.icon || '📚');
+    if (nextIcon == null) return;
+    const trimmed = nextIcon.trim();
+    if (!trimmed || trimmed === draft.icon) return;
+    setDraft((prev) => (prev ? { ...prev, icon: trimmed } : prev));
+    handleUpdate({ icon: trimmed });
+  }, [draft, handleUpdate]);
+
+  const handleTitleBlur = useCallback(() => {
+    if (!draft || !activeSection) return;
+    const trimmed = draft.title.trim();
+    if (!trimmed) {
+      setDraft((prev) => (prev ? { ...prev, title: activeSection.title } : prev));
+      return;
+    }
+    if (trimmed === activeSection.title) return;
+    handleUpdate({ title: trimmed });
+  }, [draft, activeSection, handleUpdate]);
+
+  const handleDescriptionBlur = useCallback(() => {
+    if (!draft || !activeSection) return;
+    const value = draft.description || '';
+    if (value === (activeSection.description || '')) return;
+    handleUpdate({ description: value });
+  }, [draft, activeSection, handleUpdate]);
+
+  const handleLayoutSelect = useCallback(
+    (layout) => {
+      if (!draft || draft.layout === layout) return;
+      setDraft((prev) => (prev ? { ...prev, layout } : prev));
+      handleUpdate({ layout });
+    },
+    [draft, handleUpdate],
+  );
+
+  const handleThemeEdit = useCallback(() => {
+    const el = document.getElementById('settings');
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      el.focus?.();
+    }
+  }, []);
+
+  const handlePublicToggle = useCallback(() => {
+    if (!draft) return;
+    const nextValue = !draft.public;
+    setDraft((prev) => (prev ? { ...prev, public: nextValue } : prev));
+    handleUpdate({ public: nextValue });
+  }, [draft, handleUpdate]);
+
+  const handleThemeFieldChange = useCallback((field, value) => {
+    const nextValue = field === 'radius' ? clampRadius(value) : value;
+    setThemeDraft((prev) => {
+      if (prev[field] === nextValue) return prev;
+      const nextTheme = { ...prev, [field]: nextValue };
+      setDraft((current) => {
+        if (!current) return current;
+        const baseTheme = current.theme && typeof current.theme === 'object' ? current.theme : {};
+        return { ...current, theme: { ...baseTheme, [field]: nextValue } };
+      });
+      setThemeDirty(true);
+      return nextTheme;
+    });
+  }, []);
+
+  const handleThemeRevert = useCallback(() => {
+    if (!activeSection) return;
+    const normalized = normalizeTheme(activeSection.theme);
+    setThemeDraft(normalized);
+    setDraft((prev) => (prev ? { ...prev, theme: normalized } : prev));
+    setThemeDirty(false);
+  }, [activeSection]);
+
+  const handleThemeSave = useCallback(async () => {
+    if (!themeDirty) return;
+    const payload = normalizeTheme(themeDraft);
+    const success = await handleUpdate({ theme: payload });
+    if (success) {
+      setThemeDraft(payload);
+      setDraft((prev) => (prev ? { ...prev, theme: payload } : prev));
+      setThemeDirty(false);
+    }
+  }, [themeDraft, themeDirty, handleUpdate]);
+
+  const entriesLoading = loadingEntries;
+  const appliedTheme = activeSection ? themeDraft : DEFAULT_THEME;
+  const themeVars = useMemo(() => themeToCssVars(appliedTheme), [appliedTheme]);
+
   return (
-    <div className="page two-col with-sidebar">
-      <main className="content">
-        <div className="card" style={{ marginBottom: 16 }}>
-          <div className="section-header" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
-            <h2 style={{ margin: 0, textTransform: 'capitalize' }}>{title}</h2>
-            <div style={{ display: 'flex', gap: 8 }}>
-              <button className={`pill ${showEntries ? '' : 'pill-muted'}`} onClick={() => setShowEntries(v => !v)}>
-                Entries
-              </button>
-              <a className="pill" href={`/sections/${encodeURIComponent(sectionKey)}#pages`}>Pages</a>
+    <div className="sections-page sections-detail-mode" style={themeVars}>
+      <aside className="sections-sidebar">
+        <div className="sidebar-head">
+          <h2>Sections</h2>
+          <span className="sidebar-count">{loadingSections ? '…' : sections.length}</span>
+        </div>
+
+        {fetchError && <div className="callout error">{fetchError}</div>}
+        {loadingSections && !fetchError && <div className="muted">Loading…</div>}
+
+        {!loadingSections && sections.length === 0 && (
+          <div className="empty">No sections yet. Create one from the index page.</div>
+        )}
+
+        <ul className="section-list">
+          {sections.map((section) => {
+            const active = section.key === activeSection?.key;
+            return (
+              <li key={section.key} className={`section-item ${active ? 'active' : ''}`}>
+                <button type="button" className="section-link" onClick={() => handleSelectSection(section)}>
+                  <span className="color-dot" style={{ background: section.color }} />
+                  <span className="icon">{section.icon}</span>
+                  <span className="label">{section.title}</span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </aside>
+
+      <main className="sections-main">
+        {!activeSection && !loadingSections && (
+          <div className="sections-landing">
+            <div className="sections-hero">
+              <h1>Select a section to get started</h1>
+              <p>Choose a section from the left rail to configure its overview, entries, and tasks.</p>
             </div>
           </div>
-          {loading ? (
-            <div>Loading…</div>
-          ) : showEntries ? (
-            entries.length === 0 ? (
-              <p className="muted">No entries yet for this section.</p>
-            ) : (
-              entries.map((entry) => (
-                <article className="entry-card" key={entry._id}>
-                  <div className="entry-meta">
-                    <span className="date">{entry.date}</span>
-                    {entry.mood && <span className="pill">{entry.mood}</span>}
-                    {Array.isArray(entry.tags) && entry.tags.slice(0,5).map((t,i) => (
-                      <span key={i} className="pill pill-muted">#{t}</span>
-                    ))}
-                  </div>
-                  <SafeHTML
-                    className="entry-text"
-                    html={
-                      entry?.html && entry.html.length
-                        ? entry.html
-                        : (typeof entry?.content === 'string' && /<[^>]+>/.test(entry.content))
-                          ? entry.content
-                          : (entry?.text ?? '').replaceAll('\n', '<br/>')
-                    }
-                  />
-                </article>
-              ))
-            )
-          ) : null}
-        </div>
+        )}
 
-        <div className="card" id="pages">
-          <h3 style={{ marginTop: 0 }}>Pages</h3>
-          {loading ? (
-            <div>Loading…</div>
-          ) : pages.length === 0 ? (
-            <p className="muted">No pages yet.</p>
-          ) : (
-            <ul className="unstyled">
-              {pages.map((p) => (
-                <li key={p._id}>
-                  <a className="link" href={`/sections/${encodeURIComponent(sectionKey)}/${encodeURIComponent(p.slug)}`}>
-                    {p.icon} {p.title}
-                  </a>
-                </li>
+        {activeSection && draft && (
+          <>
+            <header className="section-hero" data-sticky-context>
+              <div className="section-identity">
+                <button type="button" className="section-icon" onClick={handleIconChange} aria-label="Edit section icon">
+                  <span aria-hidden="true">{draft.icon}</span>
+                </button>
+                <div className="section-title-group">
+                  <input
+                    className="section-title-input"
+                    value={draft.title}
+                    onChange={(e) => setDraft((prev) => (prev ? { ...prev, title: e.target.value } : prev))}
+                    onBlur={handleTitleBlur}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault();
+                        e.currentTarget.blur();
+                      }
+                    }}
+                    placeholder="Untitled section"
+                    aria-label="Section title"
+                  />
+                  <span className="section-updated">Updated {new Date(activeSection.updatedAt || Date.now()).toLocaleDateString()}</span>
+                </div>
+              </div>
+
+              <div className="section-description">
+                <textarea
+                  value={draft.description}
+                  onChange={(e) => setDraft((prev) => (prev ? { ...prev, description: e.target.value } : prev))}
+                  onBlur={handleDescriptionBlur}
+                  placeholder="Describe this section"
+                  rows={Math.max(2, Math.min(6, draft.description.split('\n').length + 1))}
+                  aria-label="Section description"
+                />
+              </div>
+
+              <div className="section-controls">
+                <div className="layout-picker" role="radiogroup" aria-label="Layout">
+                  {LAYOUT_OPTIONS.map((option) => {
+                    const active = draft.layout === option.value;
+                    return (
+                      <button
+                        key={option.value}
+                        type="button"
+                        role="radio"
+                        aria-checked={active}
+                        className={`layout-pill ${active ? 'active' : ''}`}
+                        onClick={() => handleLayoutSelect(option.value)}
+                        disabled={!!updating.layout && draft.layout === option.value}
+                      >
+                        {option.label}
+                      </button>
+                    );
+                  })}
+                </div>
+
+                <button type="button" className="theme-chip" onClick={handleThemeEdit}>
+                  <span className="dot" aria-hidden="true" />
+                  Edit theme
+                </button>
+
+                <button
+                  type="button"
+                  className={`public-toggle ${draft.public ? 'is-public' : ''}`}
+                  onClick={handlePublicToggle}
+                >
+                  <span className="toggle-thumb" aria-hidden="true" />
+                  <span>{draft.public ? 'Public view on' : 'Public view off'}</span>
+                </button>
+              </div>
+            </header>
+
+            <nav className="section-subnav" aria-label="Section navigation">
+              {SUBNAV_LINKS.map((link) => (
+                <a key={link.id} href={`#${link.id}`} className="subnav-link">
+                  {link.label}
+                </a>
               ))}
-            </ul>
-          )}
-        </div>
+            </nav>
+
+            {saveError && <div className="callout error">{saveError}</div>}
+
+            <section id="overview" className="section-panel">
+              <header>
+                <h2>Overview</h2>
+                <p className="muted">Build your section with modules to spotlight the work that matters.</p>
+              </header>
+              <div className="modules-placeholder">
+                <div className="empty">
+                  <strong>No modules yet</strong>
+                  <p>Add cards, lists, or charts to craft your section dashboard.</p>
+                  <button type="button" className="cta" disabled>
+                    Add Module
+                  </button>
+                  <span className="muted">Module library coming soon.</span>
+                </div>
+              </div>
+            </section>
+
+            <section id="entries" className="section-panel">
+              <header>
+                <h2>Entries</h2>
+                <p className="muted">Recent reflections and journal notes captured in this section.</p>
+              </header>
+
+              {entriesLoading && <div className="muted">Loading entries…</div>}
+              {!entriesLoading && sortedEntries.length === 0 && (
+                <div className="empty">No entries yet. Capture your first reflection for this section.</div>
+              )}
+
+              {!entriesLoading && sortedEntries.length > 0 && (
+                <div className="entries-stack">
+                  {sortedEntries.map((entry) => (
+                    <article key={entry._id} className="entry-card">
+                      <div className="entry-meta">
+                        <span className="date">{entry.date}</span>
+                        {entry.mood && <span className="pill">{entry.mood}</span>}
+                        {Array.isArray(entry.tags) &&
+                          entry.tags.slice(0, 5).map((tag, idx) => (
+                            <span key={idx} className="pill pill-muted">#{tag}</span>
+                          ))}
+                      </div>
+                      <SafeHTML className="entry-text" html={renderEntryHtml(entry)} />
+                    </article>
+                  ))}
+                </div>
+              )}
+            </section>
+
+            <section id="tasks" className="section-panel">
+              <header>
+                <h2>Tasks</h2>
+                <p className="muted">Upcoming tasks associated with this section.</p>
+              </header>
+              <div className="tasks-panel">
+                <TaskList
+                  view="upcoming"
+                  header="Upcoming tasks"
+                  section={activeSection.slug}
+                  wrap={false}
+                />
+              </div>
+            </section>
+
+            <section id="settings" className="section-panel" tabIndex={-1}>
+              <header>
+                <h2>Settings</h2>
+                <p className="muted">Fine-tune slug, sharing, and metadata.</p>
+              </header>
+              <dl className="section-metadata">
+                <div>
+                  <dt>Slug</dt>
+                  <dd>{activeSection.slug}</dd>
+                </div>
+                <div>
+                  <dt>Layout</dt>
+                  <dd className="muted">{draft.layout}</dd>
+                </div>
+                <div>
+                  <dt>Visibility</dt>
+                  <dd className="muted">{draft.public ? 'Public' : 'Private'}</dd>
+                </div>
+                <div>
+                  <dt>Last updated</dt>
+                  <dd className="muted">
+                    {activeSection.updatedAt
+                      ? new Date(activeSection.updatedAt).toLocaleString()
+                      : 'Not available'}
+                  </dd>
+                </div>
+              </dl>
+
+              <div className="theme-editor" aria-live="polite">
+                <div className="theme-editor-head">
+                  <h3>Theme editor</h3>
+                  {themeDirty && <span className="badge">Unsaved changes</span>}
+                </div>
+                <p className="muted">
+                  Tune the colors, surface, and depth for this section. Changes preview instantly for you.
+                </p>
+
+                <div className="theme-grid">
+                  <label className="theme-field">
+                    <span>Primary</span>
+                    <input
+                      type="color"
+                      value={themeDraft.primary}
+                      onChange={(e) => handleThemeFieldChange('primary', e.target.value)}
+                      aria-label="Primary color"
+                    />
+                  </label>
+
+                  <label className="theme-field">
+                    <span>Surface</span>
+                    <input
+                      type="color"
+                      value={themeDraft.surface}
+                      onChange={(e) => handleThemeFieldChange('surface', e.target.value)}
+                      aria-label="Surface color"
+                    />
+                  </label>
+
+                  <label className="theme-field">
+                    <span>Accent</span>
+                    <input
+                      type="color"
+                      value={themeDraft.accent}
+                      onChange={(e) => handleThemeFieldChange('accent', e.target.value)}
+                      aria-label="Accent color"
+                    />
+                  </label>
+
+                  <label className="theme-field">
+                    <span>Corner radius</span>
+                    <input
+                      type="range"
+                      min="0"
+                      max="40"
+                      step="1"
+                      value={themeDraft.radius}
+                      onChange={(e) => handleThemeFieldChange('radius', Number(e.target.value))}
+                      aria-label="Corner radius"
+                    />
+                    <output>{Math.round(themeDraft.radius)}px</output>
+                  </label>
+
+                  <label className="theme-field theme-field-wide">
+                    <span>Shadow</span>
+                    <input
+                      type="text"
+                      value={themeDraft.shadow}
+                      onChange={(e) => handleThemeFieldChange('shadow', e.target.value)}
+                      placeholder="CSS box-shadow"
+                      aria-label="Shadow"
+                    />
+                  </label>
+                </div>
+
+                <div className="theme-actions">
+                  <button type="button" className="btn ghost" onClick={handleThemeRevert} disabled={!themeDirty}>
+                    Revert
+                  </button>
+                  <button
+                    type="button"
+                    className="btn primary"
+                    onClick={handleThemeSave}
+                    disabled={!themeDirty || updating.theme}
+                  >
+                    {updating.theme ? 'Saving…' : 'Save theme'}
+                  </button>
+                </div>
+              </div>
+            </section>
+          </>
+        )}
       </main>
 
-      {/* Sidebar: tasks in this section */}
       {token && (
-        <aside className="sidebar">
-          <TaskList view="today" section={sectionKey} header={`Tasks in “${title}”`} />
+        <aside className="sections-rail">
+          <TaskList view="today" section={activeSection?.slug || undefined} header="Today" />
         </aside>
       )}
     </div>

--- a/frontend/src/pages/SectionsIndex.css
+++ b/frontend/src/pages/SectionsIndex.css
@@ -1,0 +1,131 @@
+/* frontend/src/pages/SectionsIndex.css */
+.sections-index {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.5rem clamp(1rem, 3vw, 2.5rem);
+  min-height: calc(100vh - 64px);
+  box-sizing: border-box;
+}
+
+.sections-index__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.sections-index__header h1 {
+  margin: 0;
+}
+
+.sections-index__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1.25rem;
+}
+
+.sections-index__card {
+  background: var(--color-surface, rgba(15, 18, 26, 0.95));
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 18px;
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.25);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-height: 160px;
+  overflow: hidden;
+}
+
+.sections-index__card-body {
+  border: none;
+  background: transparent;
+  padding: 1.25rem 1.25rem 0.75rem;
+  display: grid;
+  grid-template-columns: 48px 1fr;
+  gap: 0.75rem;
+  text-align: left;
+  color: inherit;
+  cursor: pointer;
+}
+
+.sections-index__card-body:disabled {
+  cursor: wait;
+  opacity: 0.7;
+}
+
+.sections-index__card-body:hover:not(:disabled) {
+  background: radial-gradient(circle at top, rgba(155, 135, 245, 0.08), transparent 70%);
+}
+
+.sections-index__icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 16px;
+  background: rgba(155, 135, 245, 0.12);
+  display: grid;
+  place-items: center;
+  font-size: 1.8rem;
+}
+
+.sections-index__meta h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.sections-index__meta p {
+  margin: 0.25rem 0 0;
+  font-size: 0.9rem;
+  color: var(--color-muted, rgba(200, 205, 214, 0.75));
+}
+
+.sections-index__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding: 0.75rem 1.25rem 1.1rem;
+}
+
+.link-button {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: var(--color-thread, #9b87f5);
+  cursor: pointer;
+}
+
+.link-button:hover {
+  text-decoration: underline;
+}
+
+.link-button:disabled {
+  opacity: 0.6;
+  cursor: wait;
+  text-decoration: none;
+}
+
+.link-button.danger {
+  color: #ff6b81;
+}
+
+.empty-state {
+  border: 1px dashed rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  padding: 2rem;
+  text-align: center;
+  display: grid;
+  gap: 0.75rem;
+  justify-items: center;
+}
+
+@media (max-width: 720px) {
+  .sections-index {
+    padding: 1.25rem;
+  }
+
+  .sections-index__grid {
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  }
+}

--- a/frontend/src/pages/SectionsIndex.jsx
+++ b/frontend/src/pages/SectionsIndex.jsx
@@ -1,0 +1,314 @@
+// frontend/src/pages/SectionsIndex.jsx
+import { useContext, useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import axios from '../api/axiosInstance.js';
+import { AuthContext } from '../AuthContext.jsx';
+import '../Main.css';
+import './SectionsIndex.css';
+
+function slugify(input = '') {
+  return String(input)
+    .toLowerCase()
+    .trim()
+    .replace(/[^\p{Letter}\p{Number}]+/gu, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 96);
+}
+
+function normalizeSection(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+
+  const id = raw.id || raw._id || null;
+  const title = raw.title || raw.label || raw.name || 'Untitled section';
+  const slug = raw.slug || raw.key || slugify(title);
+  const icon = raw.icon || raw.emoji || '📚';
+  const updatedAt = raw.updatedAt || raw.updated_at || raw.modifiedAt || raw.modified_at || raw.createdAt || null;
+
+  return {
+    id,
+    title,
+    slug,
+    icon,
+    description: raw.description || raw.summary || '',
+    updatedAt,
+  };
+}
+
+function formatUpdatedAt(value) {
+  if (!value) return 'Never updated';
+  try {
+    const updated = new Date(value);
+    if (Number.isNaN(updated.getTime())) return 'Updated recently';
+
+    const now = Date.now();
+    const diffMs = updated.getTime() - now;
+    const diffMinutes = Math.round(diffMs / 60000);
+    const absMinutes = Math.abs(diffMinutes);
+
+    if (absMinutes < 1) return 'Updated just now';
+    if (absMinutes < 60) {
+      const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
+      return rtf.format(diffMinutes, 'minute');
+    }
+
+    const diffHours = Math.round(diffMinutes / 60);
+    if (Math.abs(diffHours) < 24) {
+      const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
+      return rtf.format(diffHours, 'hour');
+    }
+
+    const diffDays = Math.round(diffHours / 24);
+    if (Math.abs(diffDays) < 30) {
+      const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
+      return rtf.format(diffDays, 'day');
+    }
+
+    return `Updated ${updated.toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: updated.getFullYear() === new Date().getFullYear() ? undefined : 'numeric',
+    })}`;
+  } catch {
+    return 'Updated recently';
+  }
+}
+
+export default function SectionsIndex() {
+  const navigate = useNavigate();
+  const { token, isAuthenticated } = useContext(AuthContext);
+
+  const [sections, setSections] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [busyIds, setBusyIds] = useState(() => new Set());
+
+  useEffect(() => {
+    if (!token) {
+      setSections([]);
+      setLoading(false);
+      return;
+    }
+
+    let ignore = false;
+
+    async function loadSections() {
+      setLoading(true);
+      setError('');
+      try {
+        const res = await axios.get('/api/sections');
+        if (ignore) return;
+        const list = Array.isArray(res.data) ? res.data : [];
+        setSections(list.map(normalizeSection).filter(Boolean));
+      } catch (err) {
+        if (ignore) return;
+        console.warn('Failed to load sections:', err?.response?.data || err.message);
+        setSections([]);
+        setError(err?.response?.data?.error || 'Unable to load sections right now.');
+      } finally {
+        if (!ignore) setLoading(false);
+      }
+    }
+
+    loadSections();
+    return () => {
+      ignore = true;
+    };
+  }, [token]);
+
+  const sortedSections = useMemo(() => {
+    return [...sections].sort((a, b) => {
+      if (a.updatedAt && b.updatedAt) {
+        return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+      }
+      if (a.updatedAt) return -1;
+      if (b.updatedAt) return 1;
+      return a.title.localeCompare(b.title);
+    });
+  }, [sections]);
+
+  function setBusy(id, busy) {
+    setBusyIds((prev) => {
+      const next = new Set(prev);
+      if (busy) {
+        next.add(id);
+      } else {
+        next.delete(id);
+      }
+      return next;
+    });
+  }
+
+  async function handleCreate() {
+    const title = window.prompt('Section title');
+    if (!title) return;
+
+    const trimmed = title.trim();
+    if (!trimmed) return;
+
+    const tempId = `temp-${Date.now()}`;
+    const slug = slugify(trimmed);
+    const optimistic = {
+      id: tempId,
+      title: trimmed,
+      slug,
+      icon: '📚',
+      updatedAt: new Date().toISOString(),
+    };
+
+    setSections((prev) => [optimistic, ...prev]);
+    try {
+      const res = await axios.post('/api/sections', { title: trimmed, slug });
+      const created = normalizeSection(res.data);
+      setSections((prev) =>
+        prev.map((section) => (section.id === tempId ? created || section : section)),
+      );
+    } catch (err) {
+      console.warn('Create section failed:', err?.response?.data || err.message);
+      setSections((prev) => prev.filter((section) => section.id !== tempId));
+      alert(err?.response?.data?.error || 'Could not create the section.');
+    }
+  }
+
+  function handleOpen(section) {
+    if (!section?.slug) return;
+    navigate(`/sections/${encodeURIComponent(section.slug)}`);
+  }
+
+  async function handleRename(section) {
+    if (!section?.id) return;
+    const nextTitle = window.prompt('Rename section', section.title);
+    if (!nextTitle) return;
+
+    const trimmed = nextTitle.trim();
+    if (!trimmed || trimmed === section.title) return;
+
+    const nextSlug = slugify(trimmed);
+    const previous = { ...section };
+
+    setBusy(section.id, true);
+    setSections((prev) =>
+      prev.map((item) =>
+        item.id === section.id
+          ? { ...item, title: trimmed, slug: nextSlug, updatedAt: new Date().toISOString() }
+          : item,
+      ),
+    );
+
+    try {
+      const res = await axios.put(`/api/sections/${encodeURIComponent(section.id)}`, {
+        title: trimmed,
+        slug: nextSlug,
+      });
+      const updated = normalizeSection(res.data);
+      setSections((prev) =>
+        prev.map((item) => (item.id === section.id ? updated || item : item)),
+      );
+    } catch (err) {
+      console.warn('Rename section failed:', err?.response?.data || err.message);
+      alert(err?.response?.data?.error || 'Could not rename the section.');
+      setSections((prev) =>
+        prev.map((item) => (item.id === section.id ? previous : item)),
+      );
+    } finally {
+      setBusy(section.id, false);
+    }
+  }
+
+  async function handleDelete(section) {
+    if (!section?.id) return;
+    const confirmed = window.confirm(
+      `Delete “${section.title}”? This will remove it for everyone in your account.`,
+    );
+    if (!confirmed) return;
+
+    const before = sections;
+    setSections((prev) => prev.filter((item) => item.id !== section.id));
+
+    try {
+      await axios.delete(`/api/sections/${encodeURIComponent(section.id)}`);
+    } catch (err) {
+      console.warn('Delete section failed:', err?.response?.data || err.message);
+      alert(err?.response?.data?.error || 'Could not delete the section.');
+      setSections(before);
+    }
+  }
+
+  if (!isAuthenticated) {
+    return <div className="page" style={{ padding: '2rem' }}>Please sign in to view sections.</div>;
+  }
+
+  return (
+    <div className="page sections-index">
+      <header className="sections-index__header">
+        <div>
+          <h1>Sections</h1>
+          <p className="muted">Organise your worlds, hobbies, and quests.</p>
+        </div>
+        <button type="button" className="button" onClick={handleCreate} disabled={loading}>
+          + New Section
+        </button>
+      </header>
+
+      {error && <div className="alert alert-error">{error}</div>}
+
+      {loading ? (
+        <div className="muted">Loading sections…</div>
+      ) : sortedSections.length === 0 ? (
+        <div className="empty-state">
+          <p>No sections yet.</p>
+          <button type="button" className="button button-secondary" onClick={handleCreate}>
+            Create your first section
+          </button>
+        </div>
+      ) : (
+        <div className="sections-index__grid">
+          {sortedSections.map((section) => {
+            const busy = busyIds.has(section.id);
+            return (
+              <article key={section.id || section.slug} className="sections-index__card">
+                <button
+                  type="button"
+                  className="sections-index__card-body"
+                  onClick={() => handleOpen(section)}
+                  disabled={busy}
+                >
+                  <div className="sections-index__icon" aria-hidden>{section.icon}</div>
+                  <div className="sections-index__meta">
+                    <h3>{section.title}</h3>
+                    <p>{formatUpdatedAt(section.updatedAt)}</p>
+                  </div>
+                </button>
+                <div className="sections-index__actions">
+                  <button
+                    type="button"
+                    className="link-button"
+                    onClick={() => handleOpen(section)}
+                    disabled={busy}
+                  >
+                    Open
+                  </button>
+                  <button
+                    type="button"
+                    className="link-button"
+                    onClick={() => handleRename(section)}
+                    disabled={busy}
+                  >
+                    Rename
+                  </button>
+                  <button
+                    type="button"
+                    className="link-button danger"
+                    onClick={() => handleDelete(section)}
+                    disabled={busy}
+                  >
+                    Delete
+                  </button>
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/models/Section.js
+++ b/models/Section.js
@@ -1,20 +1,23 @@
 // models/Section.js
 import mongoose from 'mongoose';
 
-const sectionSchema = new mongoose.Schema(
+const { Schema } = mongoose;
+
+const sectionSchema = new Schema(
   {
-    userId    : { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true, index: true },
-    key       : { type: String, required: true },  // slug-ish, unique per user
-    label     : { type: String, required: true },  // display name
-    color     : { type: String, default: '#5cc2ff' },
-    icon      : { type: String, default: '📚' },
+    ownerId:     { type: Schema.Types.ObjectId, ref: 'User', required: true, index: true },
+    title:       { type: String, required: true, trim: true },
+    slug:        { type: String, required: true, trim: true },
     description: { type: String, default: '' },
-    pinned    : { type: Boolean, default: false },
-    order     : { type: Number, default: 0 },
+    icon:        { type: String, default: '' },
+    theme:       { type: Schema.Types.Mixed, default: () => ({}) },
+    layout:      { type: String, enum: ['flow', 'grid', 'kanban', 'tree'], default: 'flow' },
+    public:      { type: Boolean, default: false },
   },
   { timestamps: true }
 );
 
-sectionSchema.index({ userId: 1, key: 1 }, { unique: true });
+sectionSchema.index({ ownerId: 1, slug: 1 }, { unique: true });
+sectionSchema.index({ updatedAt: -1 });
 
 export default mongoose.model('Section', sectionSchema);

--- a/models/SectionPage.js
+++ b/models/SectionPage.js
@@ -6,7 +6,7 @@ const { Schema } = mongoose;
 const sectionPageSchema = new Schema(
   {
     userId:     { type: Schema.Types.ObjectId, ref: 'User', required: true, index: true },
-    sectionKey: { type: String, required: true, index: true },   // matches Section.key
+    sectionKey: { type: String, required: true, index: true },   // matches Section.slug
     slug:       { type: String, required: true },                 // derived from title
     title:      { type: String, required: true, trim: true },
     body:       { type: String, default: '' },                    // markdown / html / plain


### PR DESCRIPTION
## Summary
- add a normalized section theme model with helpers to apply CSS variables and persist section-level tokens from the detail page
- surface a theme editor in Section settings with live preview, revert, and save actions for primary, surface, accent, radius, and shadow
- refresh SectionPage styling to respect the scoped theme variables across the sidebar, hero, panels, and journal views

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d873217260832898573d372487ac3e