### PR TITLE
Add section entry feed filters and backend support

### DIFF
--- a/frontend/src/pages/SectionPage.css
+++ b/frontend/src/pages/SectionPage.css
@@ -247,9 +247,197 @@
   color: var(--color-muted, #9aa0aa);
 }
 
-.entries-stack {
+.entries-pane {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.entries-filter-bar {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  align-items: end;
+}
+
+.filter-field {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.filter-field label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted, #9aa0aa);
+}
+
+.filter-field input {
+  border-radius: 10px;
+  border: 1px solid var(--color-border, #2a2a32);
+  background: rgba(255, 255, 255, 0.05);
+  color: inherit;
+  padding: 0.45rem 0.6rem;
+  font-size: 0.9rem;
+}
+
+.filter-field input:focus {
+  outline: none;
+  border-color: rgba(155, 135, 245, 0.5);
+  box-shadow: 0 0 0 2px rgba(155, 135, 245, 0.2);
+}
+
+.filter-reset {
+  justify-self: end;
+  align-self: center;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-border, #2a2a32);
+  background: transparent;
+  color: var(--color-muted, #9aa0aa);
+  cursor: pointer;
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+.filter-reset:hover:not(:disabled) {
+  border-color: rgba(155, 135, 245, 0.5);
+  color: var(--color-mist, #fff);
+}
+
+.filter-reset:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.filter-warning {
+  font-size: 0.85rem;
+  color: #ffb57f;
+  background: rgba(255, 165, 90, 0.12);
+  border: 1px solid rgba(255, 165, 90, 0.3);
+  border-radius: 12px;
+  padding: 0.6rem 0.8rem;
+}
+
+.entry-feed {
   display: grid;
   gap: 1rem;
+}
+
+.entry-card {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1.1rem;
+  border-radius: 16px;
+  border: 1px solid var(--color-border, #2a2a32);
+  background: rgba(17, 17, 22, 0.78);
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.25);
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.entry-card:hover {
+  transform: translateY(-2px);
+  border-color: rgba(155, 135, 245, 0.4);
+}
+
+.entry-card.pinned {
+  border-color: rgba(255, 209, 102, 0.55);
+  box-shadow: 0 18px 36px rgba(255, 209, 102, 0.16);
+}
+
+.entry-card-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.entry-card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.entry-date {
+  font-weight: 600;
+}
+
+.entry-updated {
+  font-size: 0.75rem;
+  color: var(--color-muted, #9aa0aa);
+}
+
+.entry-flag {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #ffd166;
+  background: rgba(255, 209, 102, 0.12);
+  border: 1px solid rgba(255, 209, 102, 0.3);
+  border-radius: 999px;
+  padding: 0.15rem 0.55rem;
+}
+
+.entry-actions {
+  display: inline-flex;
+  gap: 0.4rem;
+}
+
+.entry-action {
+  border: 1px solid var(--color-border, #2a2a32);
+  background: rgba(255, 255, 255, 0.05);
+  color: inherit;
+  border-radius: 10px;
+  padding: 0.35rem 0.55rem;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.entry-action:hover:not(:disabled) {
+  border-color: rgba(155, 135, 245, 0.4);
+  background: rgba(155, 135, 245, 0.18);
+}
+
+.entry-action:disabled {
+  opacity: 0.6;
+  cursor: wait;
+}
+
+.entry-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.entries-footer {
+  display: grid;
+  gap: 0.6rem;
+  justify-items: center;
+}
+
+.entries-load-more {
+  border: 1px solid var(--color-border, #2a2a32);
+  background: transparent;
+  color: var(--color-muted, #9aa0aa);
+  border-radius: 999px;
+  padding: 0.5rem 1.1rem;
+  cursor: pointer;
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+.entries-load-more:hover {
+  border-color: rgba(155, 135, 245, 0.5);
+  color: var(--color-mist, #fff);
+}
+
+.entries-end {
+  font-size: 0.85rem;
+  color: var(--color-muted, #9aa0aa);
+}
+
+.entries-sentinel {
+  width: 100%;
+  height: 1px;
 }
 
 .pages-grid {
@@ -469,5 +657,13 @@
   .tab-group .tab {
     flex: 1 1 0;
     text-align: center;
+  }
+
+  .entries-filter-bar {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
+
+  .filter-reset {
+    justify-self: stretch;
   }
 }

--- a/frontend/src/pages/SectionPage.jsx
+++ b/frontend/src/pages/SectionPage.jsx
@@ -177,6 +177,7 @@ export default function SectionPage() {
   const normalizedSections = useMemo(() => {
     return (allSections || [])
       .map((s) => ({
+        id: s._id || s.id || null,
         key: (s.key || s.slug || '').toLowerCase(),
         label: s.label || s.name || s.key || 'Untitled section',
         icon: s.icon || s.emoji || '📚',

--- a/frontend/src/pages/SectionPage.jsx
+++ b/frontend/src/pages/SectionPage.jsx
@@ -207,13 +207,16 @@ export default function SectionPage() {
 
   const makeEntryParams = useCallback(
     (offset = 0) => {
-      if (!activeSection?.id) return null;
       const params = {
-        sectionId: activeSection.id,
         limit: PAGE_SIZE,
         offset,
       };
+      if (activeSection?.id) params.sectionId = activeSection.id;
       if (activeSection?.key) params.section = activeSection.key;
+
+      if (!params.sectionId && !params.section) {
+        return null;
+      }
 
       const { startDate, endDate, tag, mood } = filters;
       if (startDate) params.startDate = startDate;

--- a/frontend/src/pages/SectionsIndex.css
+++ b/frontend/src/pages/SectionsIndex.css
@@ -20,6 +20,71 @@
   margin: 0;
 }
 
+.sections-index__filters {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.sections-index__search-input {
+  width: min(100%, 420px);
+  padding: 0.65rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.05);
+  color: inherit;
+  font: inherit;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.sections-index__search-input:focus {
+  outline: none;
+  border-color: rgba(155, 135, 245, 0.6);
+  background: rgba(155, 135, 245, 0.12);
+}
+
+.sections-index__search-input:disabled {
+  opacity: 0.6;
+}
+
+.sections-index__quick-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.sections-index__filter-button {
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.05);
+  color: inherit;
+  font: inherit;
+  padding: 0.45rem 0.85rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.sections-index__filter-button:hover:not(:disabled) {
+  background: rgba(155, 135, 245, 0.15);
+  border-color: rgba(155, 135, 245, 0.35);
+}
+
+.sections-index__filter-button.is-active {
+  background: rgba(155, 135, 245, 0.22);
+  border-color: rgba(155, 135, 245, 0.6);
+  color: #fff;
+}
+
+.sections-index__filter-button:disabled {
+  opacity: 0.6;
+  cursor: wait;
+}
+
+.sections-index__activity-hint {
+  font-size: 0.85rem;
+}
+
 .sections-index__grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
@@ -80,6 +145,23 @@
   color: var(--color-muted, rgba(200, 205, 214, 0.75));
 }
 
+.sections-index__meta-description {
+  font-size: 0.85rem;
+  line-height: 1.35;
+  color: var(--color-muted, rgba(200, 205, 214, 0.75));
+  max-height: 3.2em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.sections-index__meta-activity {
+  font-size: 0.85rem;
+  color: var(--color-thread, #9b87f5);
+}
+
 .sections-index__actions {
   display: flex;
   justify-content: flex-end;
@@ -127,5 +209,13 @@
 
   .sections-index__grid {
     grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  }
+
+  .sections-index__filters {
+    align-items: stretch;
+  }
+
+  .sections-index__search-input {
+    width: 100%;
   }
 }

--- a/models/Entry.js
+++ b/models/Entry.js
@@ -24,7 +24,9 @@ const EntrySchema = new Schema({
   mood   : { type: String, default: "" },
   tags   : { type: [String], default: [] },
   cluster: { type: String, default: "" },    // cluster scoping
-  section: { type: String, default: "" },    // legacy / optional
+  section: { type: String, default: "" },    // legacy / optional slug
+  sectionId: { type: Schema.Types.ObjectId, ref: "Section", default: null, index: true },
+  pinned : { type: Boolean, default: false, index: true },
 
   // SectionPage room scoping
   sectionPageId: { type: Schema.Types.ObjectId, ref: "SectionPage", default: null, index: true },
@@ -38,5 +40,6 @@ const EntrySchema = new Schema({
 // Helpful compound indexes
 EntrySchema.index({ userId: 1, cluster: 1, date: -1 });
 EntrySchema.index({ userId: 1, sectionPageId: 1, date: -1 });
+EntrySchema.index({ userId: 1, sectionId: 1, date: -1, createdAt: -1 });
 
 export default mongoose.model("Entry", EntrySchema);

--- a/routes/entries.js
+++ b/routes/entries.js
@@ -2,7 +2,7 @@
 // Solidified entries API with:
 // - Toronto-safe date normalization
 // - GET by ID and GET by date (moved to /by-date/:date to avoid id clash)
-// - Query filtering (date, cluster, section, sectionPageId, limit)
+// - Query filtering (date, cluster, section, sectionId, sectionPageId, limit, tag, mood)
 // - NLP hooks for ImportantEvents/Appointments (non-fatal)
 
 import express from "express";
@@ -19,6 +19,10 @@ const router = express.Router();
 
 const { ObjectId } = mongoose.Types;
 
+function escapeRegExp(value) {
+  return String(value || "").replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
+}
+
 /* --------------------------- Routes --------------------------- */
 
 // List with flexible filters
@@ -26,17 +30,88 @@ const { ObjectId } = mongoose.Types;
 router.get("/", async (req, res) => {
   try {
     const userId = getUserIdFromRequest(req);
-    const q = { userId };
+    if (!userId) return res.status(401).json({ error: "Unauthorized" });
 
-    if (req.query.date) q.date = normalizeDate(req.query.date);
-    if (req.query.cluster) q.cluster = String(req.query.cluster);
-    if (req.query.section) q.section = String(req.query.section);
-    if (req.query.sectionPageId && ObjectId.isValid(req.query.sectionPageId)) {
-      q.sectionPageId = new ObjectId(req.query.sectionPageId);
+    const query = { userId };
+
+    const orClauses = [];
+    if (req.query.sectionId) {
+      if (!ObjectId.isValid(req.query.sectionId)) {
+        return res.status(400).json({ error: "Invalid sectionId" });
+      }
+      orClauses.push({ sectionId: new ObjectId(req.query.sectionId) });
+    }
+    if (req.query.section) {
+      orClauses.push({ section: String(req.query.section) });
     }
 
-    const limit = Math.min(Math.max(parseInt(req.query.limit || "100", 10), 1), 500);
-    const rows = await Entry.find(q).sort({ date: -1, createdAt: -1 }).limit(limit);
+    if (orClauses.length === 1) {
+      Object.assign(query, orClauses[0]);
+    } else if (orClauses.length > 1) {
+      query.$or = orClauses;
+    }
+
+    if (req.query.date) {
+      query.date = normalizeDate(req.query.date);
+    } else {
+      const dateRange = {};
+      if (req.query.startDate) {
+        dateRange.$gte = normalizeDate(req.query.startDate);
+      }
+      if (req.query.endDate) {
+        dateRange.$lte = normalizeDate(req.query.endDate);
+      }
+      if (Object.keys(dateRange).length) {
+        query.date = dateRange;
+      }
+    }
+
+    if (req.query.cluster) query.cluster = String(req.query.cluster);
+    if (req.query.sectionPageId && ObjectId.isValid(req.query.sectionPageId)) {
+      query.sectionPageId = new ObjectId(req.query.sectionPageId);
+    }
+
+    if (req.query.mood) {
+      const mood = String(req.query.mood).trim();
+      if (mood) {
+        query.mood = new RegExp(`^${escapeRegExp(mood)}$`, "i");
+      }
+    }
+
+    if (req.query.tag) {
+      const raw = Array.isArray(req.query.tag)
+        ? req.query.tag.flatMap((t) => String(t).split(","))
+        : String(req.query.tag).split(",");
+      const tagPatterns = raw
+        .map((t) => String(t).trim())
+        .filter(Boolean)
+        .map((t) => new RegExp(`^${escapeRegExp(t)}$`, "i"));
+
+      if (tagPatterns.length === 1) {
+        query.tags = tagPatterns[0];
+      } else if (tagPatterns.length > 1) {
+        query.tags = { $in: tagPatterns };
+      }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(req.query, "pinned")) {
+      const rawPinned = String(req.query.pinned).toLowerCase();
+      if (rawPinned === "true" || rawPinned === "1") query.pinned = true;
+      else if (rawPinned === "false" || rawPinned === "0") query.pinned = false;
+    }
+
+    const limitRaw = parseInt(req.query.limit ?? "100", 10);
+    const limit = Number.isFinite(limitRaw)
+      ? Math.min(Math.max(limitRaw, 1), 500)
+      : 100;
+
+    const offsetRaw = parseInt(req.query.offset ?? "0", 10);
+    const offset = Number.isFinite(offsetRaw) ? Math.max(offsetRaw, 0) : 0;
+
+    const rows = await Entry.find(query)
+      .sort({ pinned: -1, date: -1, createdAt: -1, _id: -1 })
+      .skip(offset)
+      .limit(limit);
     res.json(rows);
   } catch (e) {
     console.error("GET /entries error", e);

--- a/utils/entryAutomation.js
+++ b/utils/entryAutomation.js
@@ -376,9 +376,11 @@ function normalizeEntryForCreate(payload = {}) {
   if (!("mood" in normalized)) normalized.mood = typeof payload.mood === "string" ? payload.mood : "";
   if (!("cluster" in normalized)) normalized.cluster = typeof payload.cluster === "string" ? payload.cluster : "";
   if (!("section" in normalized)) normalized.section = typeof payload.section === "string" ? payload.section : "";
+  if (!("sectionId" in normalized)) normalized.sectionId = toObjectIdOrNull(payload.sectionId);
   if (!("tags" in normalized)) normalized.tags = deDupeTags(payload.tags);
   if (!("linkedGoal" in normalized)) normalized.linkedGoal = toObjectIdOrNull(payload.linkedGoal);
   if (!("sectionPageId" in normalized)) normalized.sectionPageId = toObjectIdOrNull(payload.sectionPageId);
+  if (!("pinned" in normalized)) normalized.pinned = !!payload.pinned;
   return normalized;
 }
 
@@ -416,6 +418,9 @@ function normalizeEntryForUpdate(payload = {}, existing = {}) {
   if (Object.prototype.hasOwnProperty.call(payload, "section")) {
     normalized.section = typeof payload.section === "string" ? payload.section : "";
   }
+  if (Object.prototype.hasOwnProperty.call(payload, "sectionId")) {
+    normalized.sectionId = toObjectIdOrNull(payload.sectionId);
+  }
   if (Object.prototype.hasOwnProperty.call(payload, "tags")) {
     normalized.tags = deDupeTags(payload.tags);
   }
@@ -424,6 +429,9 @@ function normalizeEntryForUpdate(payload = {}, existing = {}) {
   }
   if (Object.prototype.hasOwnProperty.call(payload, "sectionPageId")) {
     normalized.sectionPageId = toObjectIdOrNull(payload.sectionPageId);
+  }
+  if (Object.prototype.hasOwnProperty.call(payload, "pinned")) {
+    normalized.pinned = !!payload.pinned;
   }
   return normalized;
 }
@@ -457,9 +465,11 @@ export async function createEntryWithAutomation({ userId, payload = {} }) {
     mood: normalized.mood,
     cluster: normalized.cluster,
     section: normalized.section,
+    sectionId: normalized.sectionId,
     tags: mergedTags,
     linkedGoal: normalized.linkedGoal,
     sectionPageId: normalized.sectionPageId,
+    pinned: normalized.pinned,
     suggestedTasks,
   });
 
@@ -495,6 +505,9 @@ export async function updateEntryWithAutomation({ userId, entryId, updates = {} 
   if (Object.prototype.hasOwnProperty.call(normalized, "section")) {
     entry.section = normalized.section || "";
   }
+  if (Object.prototype.hasOwnProperty.call(normalized, "sectionId")) {
+    entry.sectionId = normalized.sectionId;
+  }
   if (Object.prototype.hasOwnProperty.call(normalized, "linkedGoal")) {
     entry.linkedGoal = normalized.linkedGoal;
   }
@@ -503,6 +516,9 @@ export async function updateEntryWithAutomation({ userId, entryId, updates = {} 
   }
   if (Object.prototype.hasOwnProperty.call(normalized, "tags")) {
     entry.tags = normalized.tags;
+  }
+  if (Object.prototype.hasOwnProperty.call(normalized, "pinned")) {
+    entry.pinned = !!normalized.pinned;
   }
 
   let analysis = null;


### PR DESCRIPTION
## Summary
- add an infinite-scroll entries feed with filter controls, pin toggles, and copy-link quick actions to the Section detail view
- extend the entries API with sectionId-aware querying, pagination, mood/tag filters, and pinned ordering, plus persist sectionId/pinned on entries
- update section activity aggregation to count entry activity by sectionId or slug so the “Most Active” filter remains accurate

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d87f76ffac8328b59062d60c71b5d2